### PR TITLE
Upgrade p256 from v0.10 => v0.13.

### DIFF
--- a/passkey-authenticator/Cargo.toml
+++ b/passkey-authenticator/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1"
 coset = "0.3"
 log = "0.4"
 mockall = { version = "0.11", optional = true }
-p256 = { version = "0.10", features = ["pem", "arithmetic", "jwk"] }
+p256 = { version = "0.13", features = ["pem", "arithmetic", "jwk"] }
 passkey-types = { path = "../passkey-types", version = "0.1.1" }
 rand = "0.8"
 tokio = { version = "1", features = ["sync"], optional = true }

--- a/passkey-authenticator/Cargo.toml
+++ b/passkey-authenticator/Cargo.toml
@@ -30,4 +30,4 @@ tokio = { version = "1", features = ["sync"], optional = true }
 mockall = { version = "0.11" }
 tokio = { version = "1", features = ["sync", "macros", "rt"] }
 generic-array = { version = "0.14", default-features = false }
-signature = { version = ">= 1.3.1, <1.5", features = ["rand-preview"] }
+signature = { version = "2", features = ["rand_core"] }

--- a/passkey-authenticator/src/authenticator/get_assertion.rs
+++ b/passkey-authenticator/src/authenticator/get_assertion.rs
@@ -121,19 +121,15 @@ where
 
         let mut private_key = SigningKey::from(secret_key);
 
-        let signature = private_key
-            .sign(&signature_target)
-            .to_der()
-            .to_bytes()
-            .to_vec()
-            .into();
+        let signature: p256::ecdsa::Signature = private_key.sign(&signature_target);
+        let signature_bytes = signature.to_der().to_bytes().to_vec().into();
 
         let user_handle = credential.user_handle.clone();
 
         Ok(Response {
             credential: Some(credential.into()),
             auth_data,
-            signature,
+            signature: signature_bytes,
             user: user_handle.map(|id| PublicKeyCredentialUserEntity {
                 id,
                 // TODO: make a Authenticator version of this struct similar to make_credential::PublicKeyCredentialRpEntity


### PR DESCRIPTION
This PR upgrades the version of `p256`, and addresses the breaking changes introduced by this upgrade. Upgrading this dependency allows `passkey-rs` to transitively install newer versions of the `signature` crate. The version of `signature` required by p256@v0.10 is incompatible with other cryptography crates in the ecosystem.

Closes https://github.com/1Password/passkey-rs/issues/3

FWIW, I'm happy to address any style changes you might prefer. I didn't put much thought into variable naming; I just made the minimum changes. Happy to improve the code quality at the request of reviewers. ^.^