### PR TITLE
CollectedClientData JSON byte serialization + other changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+.idea

--- a/passkey-client/src/lib.rs
+++ b/passkey-client/src/lib.rs
@@ -179,6 +179,7 @@ where
             challenge: encoding::base64url(&request.challenge),
             origin: origin.as_str().trim_end_matches('/').to_owned(),
             cross_origin: None,
+            unknown_keys: Default::default(),
         };
 
         // SAFETY: it is a developer error if serializing this struct fails.
@@ -302,6 +303,7 @@ where
             challenge: encoding::base64url(&request.challenge),
             origin: origin.as_str().trim_end_matches('/').to_owned(),
             cross_origin: None, //Some(false),
+            unknown_keys: Default::default(),
         };
 
         // SAFETY: it is a developer error if serializing this struct fails.

--- a/passkey-types/Cargo.toml
+++ b/passkey-types/Cargo.toml
@@ -19,8 +19,10 @@ serialize_bytes_as_base64_string = []
 bitflags = "1"
 ciborium = "0.2"
 data-encoding = "2"
+indexmap = { version = "2", features = ["serde"] }
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1", features = ["preserve_order"] }
 sha2 = "0.10"
 strum = { version = "0.24", features = ["derive"] }
 typeshare = "1"
@@ -28,4 +30,4 @@ typeshare = "1"
 coset = "0.3"
 
 [dev-dependencies]
-serde_json = "1"
+regex = "1.10"


### PR DESCRIPTION
## Summary

The WebAuthn specification uses a custom serialization format for converting `CollectedClientData` into json bytes (see [§5.8.1.1 ](https://www.w3.org/TR/webauthn-2/#clientdatajson-serialization) of the WebAuthn specification for more information). This is not needed for verification of passkey signatures but is helpful for testing. 

`CollectedClientData` is also a struct that can be [extended in the future](https://www.w3.org/TR/webauthn-2/#dictionary-client-data). This PR added a new field under `CollectedClientData` called `unknown_keys` to ensure that new fields would be serialized correctly

Lastly, this PR implements some dependency bumps to ensure `passkey-rs` is up to date and compatible with other rust projects that may consume it.

### Detailed changes
- [x] Added json byte serialization for `clientDataJSON` via `to_json_bytes()`
- [x] Made `CollectedClientData` extendable in the event that new fields are added in the future, changed field macros to ensure serde would serialize them properly if empty (see §5.8.1.1 of the WebAuthn specification)
- [x] Added indexmap to ensure keys preserve order during serialization (unlike BTreeMap)


## Test plan
- [x] Created tests for extended `CollectedClientData` struct json byte encoding, using a Secure Payment Confirmation (SPC) payload
- [x] Created tests for normal `CollectedClientData` struct json byte encoding
- [x] All tests pass, ran `cargo clippy` and `cargo fmt` and `cargo test`