### PR TITLE
Updates from internal mirror

### DIFF
--- a/passkey-authenticator/src/authenticator.rs
+++ b/passkey-authenticator/src/authenticator.rs
@@ -24,6 +24,9 @@ pub struct Authenticator<S, U> {
     transports: Vec<webauthn::AuthenticatorTransport>,
     /// Provider of user verification factor.
     user_validation: U,
+
+    /// The display name given when a [`webauthn::CredentialPropertiesOutput`] is requested
+    display_name: Option<String>,
 }
 
 impl<S, U> Authenticator<S, U>
@@ -43,7 +46,18 @@ where
                 webauthn::AuthenticatorTransport::Hybrid,
             ],
             user_validation: user,
+            display_name: None,
         }
+    }
+
+    /// Set the authenticator's display name which will be returned if [`webauthn::CredentialPropertiesOutput`] is requested.
+    pub fn set_display_name(&mut self, name: String) {
+        self.display_name = Some(name);
+    }
+
+    /// Get a reference to the authenticators display name to return in [`webauthn::CredentialPropertiesOutput`].
+    pub fn display_name(&self) -> Option<&String> {
+        self.display_name.as_ref()
     }
 
     /// Access the [`CredentialStore`] to look into what is stored.

--- a/passkey-authenticator/src/authenticator/get_info.rs
+++ b/passkey-authenticator/src/authenticator/get_info.rs
@@ -18,6 +18,7 @@ impl<S: CredentialStore, U: UserValidationMethod> Authenticator<S, U> {
             }),
             max_msg_size: None,
             pin_protocols: None,
+            transports: Some(self.transports.clone()),
         }
     }
 }

--- a/passkey-authenticator/src/lib.rs
+++ b/passkey-authenticator/src/lib.rs
@@ -207,8 +207,7 @@ mod tests {
         let secret_key = private_key_from_cose_key(&private_cose).expect("to get a private key");
 
         let private_key = SigningKey::from(secret_key);
-
-        let signature: p256::ecdsa::Signature = SigningKey::sign(&private_key, &signature_target);
+        let signature: p256::ecdsa::Signature = private_key.sign(&signature_target);
 
         public_key
             .verify(&signature_target, &signature)

--- a/passkey-authenticator/src/u2f.rs
+++ b/passkey-authenticator/src/u2f.rs
@@ -162,9 +162,8 @@ mod tests {
     use super::{AuthenticationRequest, Authenticator, RegisterRequest};
     use crate::{u2f::U2fApi, user_validation::MockUserValidationMethod};
     use generic_array::GenericArray;
-    use p256::ecdsa::signature::Verifier;
     use p256::{
-        ecdsa::{Signature, VerifyingKey},
+        ecdsa::{signature::Verifier, Signature, VerifyingKey},
         EncodedPoint,
     };
     use passkey_types::{ctap2::Aaguid, *};

--- a/passkey-client/src/lib.rs
+++ b/passkey-client/src/lib.rs
@@ -258,7 +258,7 @@ where
                 transports: auth_info.transports,
             },
             client_extension_results: AuthenticationExtensionsClientOutputs {},
-            authenticator_attachment: self.authenticator().attachment_type(),
+            authenticator_attachment: Some(self.authenticator().attachment_type()),
         };
 
         Ok(response)
@@ -332,7 +332,7 @@ where
                 signature: ctap2_response.signature,
                 user_handle: ctap2_response.user.map(|user| user.id),
             },
-            authenticator_attachment: self.authenticator().attachment_type(),
+            authenticator_attachment: Some(self.authenticator().attachment_type()),
             client_extension_results: AuthenticationExtensionsClientOutputs {},
         })
     }

--- a/passkey-client/src/lib.rs
+++ b/passkey-client/src/lib.rs
@@ -331,6 +331,7 @@ where
                 authenticator_data: ctap2_response.auth_data.to_vec().into(),
                 signature: ctap2_response.signature,
                 user_handle: ctap2_response.user.map(|user| user.id),
+                attestation_object: None,
             },
             authenticator_attachment: Some(self.authenticator().attachment_type()),
             client_extension_results: AuthenticationExtensionsClientOutputs {},

--- a/passkey-client/src/lib.rs
+++ b/passkey-client/src/lib.rs
@@ -58,9 +58,7 @@ impl From<ctap2::StatusCode> for WebauthnError {
     fn from(value: ctap2::StatusCode) -> Self {
         match value {
             ctap2::StatusCode::Ctap1(u2f) => WebauthnError::AuthenticatorError(u2f.into()),
-            ctap2::StatusCode::Ctap2(ctap2code)
-                if ctap2code == ctap2::Ctap2Code::Known(ctap2::Ctap2Error::NoCredentials) =>
-            {
+            ctap2::StatusCode::Ctap2(ctap2::Ctap2Code::Known(ctap2::Ctap2Error::NoCredentials)) => {
                 WebauthnError::CredentialNotFound
             }
             ctap2::StatusCode::Ctap2(ctap2code) => {

--- a/passkey-client/src/lib.rs
+++ b/passkey-client/src/lib.rs
@@ -161,6 +161,7 @@ where
     ) -> Result<webauthn::CreatedPublicKeyCredential, WebauthnError> {
         // extract inner value of request as there is nothing else of value directly in CredentialCreationOptions
         let request = request.public_key;
+        let auth_info = self.authenticator.get_info();
 
         // TODO: Handle given timeout here, If the value is not within what we consider a reasonable range
         // override to our default
@@ -254,10 +255,7 @@ where
                 public_key,
                 public_key_algorithm: alg,
                 attestation_object: attestation_object.into(),
-                transports: Some(vec![
-                    webauthn::AuthenticatorTransport::Internal,
-                    // TODO: Add Hybrid once we support the android API
-                ]),
+                transports: auth_info.transports,
             },
             client_extension_results: AuthenticationExtensionsClientOutputs {},
             authenticator_attachment: self.authenticator().attachment_type(),

--- a/passkey-client/src/tests/mod.rs
+++ b/passkey-client/src/tests/mod.rs
@@ -165,13 +165,7 @@ async fn create_and_authenticate_without_rp_id() {
 
 #[test]
 fn validate_rp_id() -> Result<(), ParseError> {
-    let auth = Authenticator::new(
-        ctap2::Aaguid::new_empty(),
-        MemoryStore::new(),
-        MockUserValidationMethod::verified_user(0),
-    );
-
-    let client = Client::new(auth);
+    let client = RpIdVerifier::new(public_suffix::DEFAULT_PROVIDER);
 
     let example = "https://example.com".parse()?;
     let com_tld = client.assert_domain(&example, Some("com"));
@@ -231,13 +225,7 @@ impl public_suffix::EffectiveTLDProvider for BrokenTLDProvider {
 #[test]
 fn validate_domain_with_private_list_provider() -> Result<(), ParseError> {
     let my_custom_provider = BrokenTLDProvider {};
-    let auth = Authenticator::new(
-        ctap2::Aaguid::new_empty(),
-        MemoryStore::new(),
-        MockUserValidationMethod::verified_user(0),
-    );
-
-    let client = Client::new_with_custom_tld_provider(auth, my_custom_provider);
+    let client = RpIdVerifier::new(my_custom_provider);
 
     // Notice that, in this test, this is a legitimate origin/rp_id combination
     // We assert that this produces an error to prove that we are indeed using our

--- a/passkey-client/src/tests/mod.rs
+++ b/passkey-client/src/tests/mod.rs
@@ -59,7 +59,7 @@ async fn create_and_authenticate() {
         public_key: good_credential_creation_options(),
     };
     let cred = client
-        .register(&origin, options)
+        .register(&origin, options, None)
         .await
         .expect("failed to register with options");
 
@@ -92,7 +92,7 @@ async fn create_and_authenticate_with_origin_subdomain() {
         public_key: good_credential_creation_options(),
     };
     let cred = client
-        .register(&origin, options)
+        .register(&origin, options, None)
         .await
         .expect("failed to register with options");
 
@@ -136,7 +136,7 @@ async fn create_and_authenticate_without_rp_id() {
         },
     };
     let cred = client
-        .register(&origin, options)
+        .register(&origin, options, None)
         .await
         .expect("failed to register with options");
 

--- a/passkey-client/src/tests/mod.rs
+++ b/passkey-client/src/tests/mod.rs
@@ -24,6 +24,7 @@ fn good_credential_creation_options() -> webauthn::PublicKeyCredentialCreationOp
         exclude_credentials: Default::default(),
         authenticator_selection: Default::default(),
         attestation: Default::default(),
+        attestation_formats: Default::default(),
         extensions: Default::default(),
     }
 }
@@ -41,6 +42,8 @@ fn good_credential_request_options(
             transports: None,
         }]),
         user_verification: Default::default(),
+        attestation: Default::default(),
+        attestation_formats: Default::default(),
         extensions: Default::default(),
     }
 }

--- a/passkey-client/src/tests/mod.rs
+++ b/passkey-client/src/tests/mod.rs
@@ -45,12 +45,29 @@ fn good_credential_request_options(
     }
 }
 
+fn uv_mock_with_creation(times: usize) -> MockUserValidationMethod {
+    let mut user_mock = MockUserValidationMethod::new();
+    user_mock
+        .expect_is_verification_enabled()
+        .returning(|| Some(true))
+        .times(times + 1);
+    user_mock
+        .expect_check_user_verification()
+        .returning(|| Box::pin(async { true }))
+        .times(times);
+    user_mock
+        .expect_is_presence_enabled()
+        .returning(|| true)
+        .times(1);
+    user_mock
+}
+
 #[tokio::test]
 async fn create_and_authenticate() {
     let auth = Authenticator::new(
         ctap2::Aaguid::new_empty(),
         MemoryStore::new(),
-        MockUserValidationMethod::verified_user(2),
+        uv_mock_with_creation(2),
     );
     let mut client = Client::new(auth);
 
@@ -83,7 +100,7 @@ async fn create_and_authenticate_with_origin_subdomain() {
     let auth = Authenticator::new(
         ctap2::Aaguid::new_empty(),
         MemoryStore::new(),
-        MockUserValidationMethod::verified_user(2),
+        uv_mock_with_creation(2),
     );
     let mut client = Client::new(auth);
 
@@ -121,7 +138,7 @@ async fn create_and_authenticate_without_rp_id() {
     let auth = Authenticator::new(
         ctap2::Aaguid::new_empty(),
         MemoryStore::new(),
-        MockUserValidationMethod::verified_user(2),
+        uv_mock_with_creation(2),
     );
     let mut client = Client::new(auth);
 

--- a/passkey-types/src/webauthn.rs
+++ b/passkey-types/src/webauthn.rs
@@ -10,9 +10,10 @@ use crate::{utils::serde::ignore_unknown, Bytes};
 mod assertion;
 mod attestation;
 mod common;
+mod extensions;
 
 // re-export types
-pub use self::{assertion::*, attestation::*, common::*};
+pub use self::{assertion::*, attestation::*, common::*, extensions::*};
 
 mod sealed {
     pub trait Sealed {}
@@ -71,16 +72,6 @@ pub struct PublicKeyCredential<R: AuthenticatorResponse> {
 
     /// This object is a map containing extension identifier → client extension output entries
     /// produced by the extension’s client extension processing.
-    pub client_extension_results: AuthenticationExtensionsClientOutputs,
+    #[serde(default)]
+    pub client_extension_results: AuthenticatorExtensionsClientOutputs,
 }
-
-/// This is a dictionary containing the client extension output values for zero or more
-/// [WebAuthn Extensions]. There are currently none supported.
-///
-/// <https://w3c.github.io/webauthn/#dictdef-authenticationextensionsclientoutputs>
-///
-/// [WebAuthn Extensions]: https://w3c.github.io/webauthn/#webauthn-extensions
-#[derive(Debug, Deserialize, Serialize, Clone)]
-#[serde(rename_all = "camelCase")]
-#[typeshare]
-pub struct AuthenticationExtensionsClientOutputs {}

--- a/passkey-types/src/webauthn.rs
+++ b/passkey-types/src/webauthn.rs
@@ -5,7 +5,7 @@
 use serde::{Deserialize, Serialize};
 use typeshare::typeshare;
 
-use crate::Bytes;
+use crate::{utils::serde::ignore_unknown, Bytes};
 
 mod assertion;
 mod attestation;
@@ -62,7 +62,12 @@ pub struct PublicKeyCredential<R: AuthenticatorResponse> {
     pub response: R,
 
     /// This reports the modality of the communication between the client and authenticator.
-    pub authenticator_attachment: AuthenticatorAttachment,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "ignore_unknown"
+    )]
+    pub authenticator_attachment: Option<AuthenticatorAttachment>,
 
     /// This object is a map containing extension identifier → client extension output entries
     /// produced by the extension’s client extension processing.

--- a/passkey-types/src/webauthn/assertion.rs
+++ b/passkey-types/src/webauthn/assertion.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use typeshare::typeshare;
 
 use crate::{
-    utils::serde::{ignore_unknown, ignore_unknown_opt_vec},
+    utils::serde::{ignore_unknown, ignore_unknown_opt_vec, maybe_stringified},
     webauthn::{
         common::{
             AuthenticationExtensionsClientInputs, PublicKeyCredentialDescriptor,
@@ -42,7 +42,11 @@ pub struct PublicKeyCredentialRequestOptions {
     /// This OPTIONAL member specifies a time, in milliseconds, that the Relying Party is willing to
     /// wait for the call to complete. The value is treated as a hint, and MAY be overridden by the
     /// client.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "maybe_stringified"
+    )]
     pub timeout: Option<u32>,
 
     /// This OPTIONAL member specifies the [RP ID] claimed by the [Relying Party]. The client MUST
@@ -102,7 +106,7 @@ pub struct PublicKeyCredentialRequestOptions {
     /// those capable of satisfying this requirement.
     ///
     /// See [`UserVerificationRequirement`] for the description of this field's values and semantics.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "ignore_unknown")]
     pub user_verification: UserVerificationRequirement,
 
     /// The Relying Party MAY use this OPTIONAL member to provide client extension inputs requesting

--- a/passkey-types/src/webauthn/attestation.rs
+++ b/passkey-types/src/webauthn/attestation.rs
@@ -350,7 +350,7 @@ pub struct AuthenticatorSelectionCriteria {
 /// <https://w3c.github.io/webauthn/#enumdef-residentkeyrequirement>
 ///
 /// [discoverable credential]: https://w3c.github.io/webauthn/#client-side-discoverable-credential
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 #[typeshare(serialized_as = "String")]
 pub enum ResidentKeyRequirement {
@@ -387,7 +387,7 @@ pub enum ResidentKeyRequirement {
 /// <https://w3c.github.io/webauthn/#enumdef-attestationconveyancepreference>
 ///
 /// [attestation conveyance]: https://w3c.github.io/webauthn/#attestation-conveyance
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 #[typeshare(serialized_as = "String")]
 pub enum AttestationConveyancePreference {
@@ -436,7 +436,7 @@ pub enum AttestationConveyancePreference {
 ///
 /// [1]: https://www.iana.org/assignments/webauthn/webauthn.xhtml#webauthn-attestation-statement-format-ids
 /// [2]: https://w3c.github.io/webauthn/#sctn-attstn-fmt-ids
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 #[typeshare]
 pub enum AttestationStatementFormatIdentifiers {
@@ -559,7 +559,7 @@ pub struct CollectedClientData {
 }
 
 /// Used to limit the values of [`CollectedClientData::ty`] and serializes to static strings.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 #[typeshare]
 pub enum ClientDataType {
     /// Serializes to the string `"webauthn.create"`

--- a/passkey-types/src/webauthn/common.rs
+++ b/passkey-types/src/webauthn/common.rs
@@ -128,7 +128,7 @@ pub enum UserVerificationRequirement {
 /// the supported transports for a [`PublicKeyCredential`] via [`AuthenticatorAttestationResponse::transports`].
 ///
 /// <https://w3c.github.io/webauthn/#enum-transport>
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 #[typeshare(serialized_as = "String")]
 pub enum AuthenticatorTransport {

--- a/passkey-types/src/webauthn/common.rs
+++ b/passkey-types/src/webauthn/common.rs
@@ -14,17 +14,6 @@ use crate::webauthn::{
     PublicKeyCredentialRequestOptions,
 };
 
-/// This is a dictionary containing the client extension input values for zero or more
-/// [WebAuthn Extensions]. There are currently none supported.
-///
-/// <https://w3c.github.io/webauthn/#dictdef-authenticationextensionsclientinputs>
-///
-/// [WebAuthn Extensions]: https://w3c.github.io/webauthn/#webauthn-extensions
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-#[typeshare]
-pub struct AuthenticationExtensionsClientInputs {}
-
 /// This enumeration defines the valid credential types. It is an extension point; values can be
 /// added to it in the future, as more credential types are defined. The values of this enumeration
 /// are used for versioning the Authentication Assertion and attestation structures according to the

--- a/passkey-types/src/webauthn/common.rs
+++ b/passkey-types/src/webauthn/common.rs
@@ -20,7 +20,7 @@ use crate::webauthn::{
 /// type of the authenticator.
 ///
 /// <https://w3c.github.io/webauthn/#enumdef-publickeycredentialtype>
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 #[typeshare(serialized_as = "String")]
 pub enum PublicKeyCredentialType {
@@ -91,7 +91,7 @@ impl PublicKeyCredentialDescriptor {
 /// <https://w3c.github.io/webauthn/#enumdef-userverificationrequirement>
 ///
 /// [user verification]: https://w3c.github.io/webauthn/#user-verification
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 #[typeshare(serialized_as = "String")]
 pub enum UserVerificationRequirement {
@@ -148,7 +148,7 @@ pub enum AuthenticatorTransport {
 /// authenticator attachment modality used to complete a registration or authentication ceremony.
 ///
 /// <https://w3c.github.io/webauthn/#enumdef-authenticatorattachment>
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 #[typeshare(serialized_as = "String")]
 pub enum AuthenticatorAttachment {

--- a/passkey-types/src/webauthn/extensions.rs
+++ b/passkey-types/src/webauthn/extensions.rs
@@ -1,0 +1,87 @@
+use serde::{Deserialize, Serialize};
+use typeshare::typeshare;
+
+#[cfg(doc)]
+use crate::webauthn::PublicKeyCredential;
+
+/// This is a dictionary containing the client extension input values for zero or more
+/// [WebAuthn Extensions]. There are currently none supported.
+///
+/// <https://w3c.github.io/webauthn/#dictdef-authenticationextensionsclientinputs>
+///
+/// [WebAuthn Extensions]: https://w3c.github.io/webauthn/#webauthn-extensions
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[typeshare]
+pub struct AuthenticationExtensionsClientInputs {
+    /// Boolean to indicate that this extension is requested by the relying party.
+    ///
+    /// See [`CredentialPropertiesOutput`] for more information.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cred_props: Option<bool>,
+}
+
+/// This is a dictionary containing the client extension output values for zero or more
+/// [WebAuthn Extensions].
+///
+/// <https://w3c.github.io/webauthn/#dictdef-authenticationextensionsclientoutputs>
+///
+/// [WebAuthn Extensions]: https://w3c.github.io/webauthn/#webauthn-extensions
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[typeshare]
+pub struct AuthenticatorExtensionsClientOutputs {
+    /// Contains properties of the given [`PublicKeyCredential`] when it is included.
+    ///
+    /// See [`CredentialPropertiesOutput`] for more information
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cred_props: Option<CredentialPropertiesOutput>,
+}
+
+/// This client registration extension facilitates reporting certain credential properties known by
+/// the client to the requesting WebAuthn [Relying Party] upon creation of a [`PublicKeyCredential`]
+/// source as a result of a registration ceremony.
+///
+/// <https://w3c.github.io/webauthn/#sctn-authenticator-credential-properties-extension>
+///
+/// [Relying Party]: https://w3c.github.io/webauthn/#relying-party
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[typeshare]
+pub struct CredentialPropertiesOutput {
+    /// This OPTIONAL property, known abstractly as the resident key credential property
+    /// (i.e., client-side [discoverable credential] property), is a Boolean value indicating whether
+    /// the [`PublicKeyCredential`] returned as a result of a registration ceremony is a client-side
+    /// [discoverable credential].
+    /// * If `rk` is true, the credential is a [discoverable credential].
+    /// * If `rk` is false, the credential is a [server-side credential].
+    /// * If `rk` is not present, it is not known whether the credential is a [discoverable credential]
+    ///   or a [server-side credential].
+    ///
+    /// [discoverable credential]: https://w3c.github.io/webauthn/#discoverable-credential
+    /// [server-side credential]: https://w3c.github.io/webauthn/#server-side-public-key-credential-source
+    #[serde(rename = "rk", default, skip_serializing_if = "Option::is_none")]
+    pub discoverable: Option<bool>,
+
+    /// This OPTIONAL property is a human-palatable description of the credential’s managing
+    /// authenticator, chosen by the user.
+    ///
+    /// The client MUST allow the user to choose this value, MAY or MAY not present that choice
+    /// during registration ceremonies, and MAY reuse the same value for multiple credentials with
+    /// the same managing authenticator across multiple Relying Parties.
+    ///
+    /// The client MAY query the authenticator, by some unspecified mechanism, for this value.
+    /// The authenticator MAY allow the user to configure the response to such a query.
+    /// The authenticator vendor MAY provide a default response to such a query. The client MAY
+    /// consider a user-configured response chosen by the user, and SHOULD allow the user to
+    /// modify a vendor-provided default response.
+    ///
+    /// If the Relying Party includes an `authenticatorDisplayName` item in credential records, the
+    /// Relying Party MAY offer this value, if present, as a default value for the
+    /// `authenticatorDisplayName` of the new credential record.
+    ///
+    /// NOTE: This is still [in proposal](https://github.com/w3c/webauthn/pull/1880), we are
+    /// implementing it here to show our backing to this feature
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authenticator_display_name: Option<String>,
+}

--- a/passkey/examples/usage.rs
+++ b/passkey/examples/usage.rs
@@ -68,7 +68,7 @@ async fn client_setup(
     };
 
     // Now create the credential.
-    let my_webauthn_credential = my_client.register(origin, request).await?;
+    let my_webauthn_credential = my_client.register(origin, request, None).await?;
 
     // Let's try and authenticate.
     // Create a challenge that would usually come from the RP.

--- a/passkey/examples/usage.rs
+++ b/passkey/examples/usage.rs
@@ -63,6 +63,7 @@ async fn client_setup(
             exclude_credentials: None,
             authenticator_selection: None,
             attestation: AttestationConveyancePreference::None,
+            attestation_formats: None,
             extensions: None,
         },
     };
@@ -81,6 +82,8 @@ async fn client_setup(
             rp_id: Some(String::from(origin.domain().unwrap())),
             allow_credentials: None,
             user_verification: UserVerificationRequirement::default(),
+            attestation: AttestationConveyancePreference::None,
+            attestation_formats: None,
             extensions: None,
         },
     };

--- a/passkey/src/lib.rs
+++ b/passkey/src/lib.rs
@@ -138,7 +138,7 @@
 //! };
 //!
 //! // Now create the credential.
-//! let my_webauthn_credential = my_client.register(&origin, request).await.unwrap();
+//! let my_webauthn_credential = my_client.register(&origin, request, None).await.unwrap();
 //!
 //! // Let's try and authenticate.
 //! // Create a challenge that would usually come from the RP.

--- a/passkey/src/lib.rs
+++ b/passkey/src/lib.rs
@@ -133,6 +133,7 @@
 //!         exclude_credentials: None,
 //!         authenticator_selection: None,
 //!         attestation: AttestationConveyancePreference::None,
+//!         attestation_formats: None,
 //!         extensions: None,
 //!     },
 //! };
@@ -151,6 +152,8 @@
 //!         rp_id: Some(String::from(origin.domain().unwrap())),
 //!         allow_credentials: None,
 //!         user_verification: UserVerificationRequirement::default(),
+//!         attestation: AttestationConveyancePreference::None,
+//!         attestation_formats: None,
 //!         extensions: None,
 //!     },
 //! };


### PR DESCRIPTION
This PR follows #7 and updates `passkey-types`, `passkey-client` and `passkey-authenticator` with changes from the internal mirror. These changes include:
* Extracting rpId verification into its own struct for re-use
* Support for mobile 3rd party authenticator APIs which provide their own clientDataJSON that we must use.
* Fixes for deserialization edge cases, namely an optional field, and stringified timeouts and algorithm specifiers
* support for w3c/webauthn#1920
* Implement [CredProps extension](https://w3c.github.io/webauthn/#sctn-authenticator-credential-properties-extension) with support for authenticatorDisplayName implemented in w3c/webauthn#1880
* other fixes and code quality improvements

Commit by commit review is recommended