### PR TITLE
Gracefully handle empty cred params

### DIFF
--- a/passkey-client/src/lib.rs
+++ b/passkey-client/src/lib.rs
@@ -170,6 +170,11 @@ where
         let request = request.public_key;
         let auth_info = self.authenticator.get_info();
 
+        let pub_key_cred_params = if request.pub_key_cred_params.is_empty() {
+            webauthn::PublicKeyCredentialParameters::default_algorithms()
+        } else {
+            request.pub_key_cred_params
+        };
         // TODO: Handle given timeout here, If the value is not within what we consider a reasonable range
         // override to our default
         // let timeout = request
@@ -213,7 +218,7 @@ where
                     name: Some(request.rp.name),
                 },
                 user: request.user,
-                pub_key_cred_params: request.pub_key_cred_params,
+                pub_key_cred_params,
                 exclude_list: request.exclude_credentials,
                 extensions: request.extensions,
                 options: ctap2::make_credential::Options {

--- a/passkey-types/src/webauthn/attestation.rs
+++ b/passkey-types/src/webauthn/attestation.rs
@@ -294,6 +294,29 @@ pub struct PublicKeyCredentialParameters {
     pub alg: iana::Algorithm,
 }
 
+impl PublicKeyCredentialParameters {
+    /// Create an array with the default algorithms in case
+    /// [`PublicKeyCredentialCreationOptions::pub_key_cred_params`] comes in empty.
+    ///
+    /// This array contains:
+    /// * [`iana::Algorithm::ES256`]
+    /// * [`iana::Algorithm::RS256`]
+    ///
+    /// <https://w3c.github.io/webauthn/#ref-for-list-size>
+    pub fn default_algorithms() -> Vec<Self> {
+        vec![
+            Self {
+                ty: PublicKeyCredentialType::PublicKey,
+                alg: iana::Algorithm::ES256,
+            },
+            Self {
+                ty: PublicKeyCredentialType::PublicKey,
+                alg: iana::Algorithm::RS256,
+            },
+        ]
+    }
+}
+
 /// [Relying Parties] may use this type to specify their requirements regarding authenticator attributes.
 ///
 /// <https://w3c.github.io/webauthn/#dictdef-authenticatorselectioncriteria>


### PR DESCRIPTION
If a creation request has an empty credential parameters we fill it out with ES256 and RS256

Closes #14