### PR TITLE
Fix header levels in top-level inline docs

### DIFF
--- a/passkey/src/lib.rs
+++ b/passkey/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! Examples in this documentation shows certain values being assumed to come from the website (Relying Party). It is not within the scope of these libraries to manage the details of the interaction with the Relying Party. How these values and the authentication results are communicated with the Relying Party is an implementation detail for users of these crates.
 //!
-//! # Basic Concepts
+//! ## Basic Concepts
 //!
 //! Conceptually, working with Passkeys involves receiving requests for registration of new credentials, storing those credentials, and performing authentication with existing credentials. Two standards are involved here: [Webauthn][webauthn-3] is the protocol by which a website (a "Relying Party") communicates with your application. The [Client-to-Authenticator Protocol (CTAP2)][ctap-2] is the protocol by which your application communicates with an authenticator - which can be software or a hardware device such as a FIDO2 USB key.
 //!
@@ -55,7 +55,7 @@
 //! [public-suffix]: https://publicsuffix.org/
 //! [ctap-hid]: https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html#usb
 //!
-//! ## Example: Using the Client type for Webauthn Operations
+//! ### Example: Using the Client type for Webauthn Operations
 //!
 //! The highest-level type in these libraries is the `passkey-client::Client`. This is the type you will primarily use to implement Webauthn authentication in your application.
 //!
@@ -166,7 +166,7 @@
 //!     .unwrap();
 //! # })
 //! ```
-//! ## Example: Using the Authenticator for CTAP2 Operations
+//! ### Example: Using the Authenticator for CTAP2 Operations
 //!
 //! The following code provides a basic example of how to create and use an `Authenticator` by itself to generate a credential and store it.
 //!


### PR DESCRIPTION
There is only one `#` top level header per document, in Markdown. Having mutliple will have the `docs.rs` parser ignore them.

Just look for `Basic Concepts` in the docs @ https://docs.rs/passkey/0.2.0/passkey/index.html to see what I mean. It's not rendered as a header. 