### PR TITLE
fix: remove unused qualifications

### DIFF
--- a/passkey-authenticator/src/lib.rs
+++ b/passkey-authenticator/src/lib.rs
@@ -58,7 +58,7 @@ fn private_key_from_cose_key(key: &CoseKey) -> Result<SecretKey, Ctap2Error> {
     if !matches!(
         key.alg,
         Some(coset::RegisteredLabelWithPrivate::Assigned(
-            iana::Algorithm::ES256
+            Algorithm::ES256
         ))
     ) {
         return Err(Ctap2Error::UnsupportedAlgorithm);
@@ -94,7 +94,7 @@ pub fn public_key_der_from_cose_key(key: &CoseKey) -> Result<Bytes, Ctap2Error> 
     if !matches!(
         key.alg,
         Some(coset::RegisteredLabelWithPrivate::Assigned(
-            iana::Algorithm::ES256
+            Algorithm::ES256
         ))
     ) {
         return Err(Ctap2Error::UnsupportedAlgorithm);

--- a/passkey-authenticator/src/u2f.rs
+++ b/passkey-authenticator/src/u2f.rs
@@ -90,9 +90,8 @@ impl<S: CredentialStore + Sync + Send, U: UserValidationMethod + Sync + Send> U2
             signature,
         };
 
-        let (passkey, user, rp) = passkey_types::Passkey::wrap_u2f_registration_request(
-            &request, &response, handle, &private,
-        );
+        let (passkey, user, rp) =
+            Passkey::wrap_u2f_registration_request(&request, &response, handle, &private);
 
         let result = self.store_mut().save_credential(passkey, user, rp).await;
 

--- a/passkey-types/src/utils/bytes.rs
+++ b/passkey-types/src/utils/bytes.rs
@@ -100,7 +100,7 @@ impl Serialize for Bytes {
         S: serde::Serializer,
     {
         if cfg!(feature = "serialize_bytes_as_base64_string") {
-            serializer.serialize_str(&crate::encoding::base64url(&self.0))
+            serializer.serialize_str(&encoding::base64url(&self.0))
         } else {
             serializer.serialize_bytes(&self.0)
         }

--- a/public-suffix/src/lib.rs
+++ b/public-suffix/src/lib.rs
@@ -285,6 +285,12 @@ impl<T: Table> ListProvider<T> {
     }
 }
 
+impl<T: Table> Default for ListProvider<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 fn after_or_all(dot: Option<usize>) -> RangeFrom<usize> {
     match dot {
         Some(dot) => (dot + 1)..,


### PR DESCRIPTION
Newer versions of rust (`rustc 1.78.0 (9b00956e5 2024-04-29`) throw build errors due to stricter linting rules. This PR fixes those errors
