### PR TITLE
Stop harcoding RK value sent to the authenticator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### passkey-client
 
 - Changed: The `Client` no longer hardcodes the UV value sent to the `Authenticator` ([#22](https://github.com/1Password/passkey-rs/pull/22)).
+- Changed: The `Client` no longer hardcodes the RK value sent to the `Authenticator` ([#27](https://github.com/1Password/passkey-rs/pull/27)).
 
 ## Passkey v0.2.0
 ### passkey-types v0.2.0

--- a/passkey-authenticator/src/credential_store.rs
+++ b/passkey-authenticator/src/credential_store.rs
@@ -14,7 +14,7 @@ use passkey_types::{
 #[async_trait::async_trait]
 pub trait CredentialStore {
     /// Defines the return type of find_credentials(...)
-    type PasskeyItem: TryInto<Passkey> + Clone + Send;
+    type PasskeyItem: TryInto<Passkey> + Send + Sync;
 
     /// Find all credentials matching the given `ids` and `rp_id`.
     ///

--- a/passkey-authenticator/src/user_validation.rs
+++ b/passkey-authenticator/src/user_validation.rs
@@ -19,7 +19,7 @@ pub struct UserCheck {
 #[async_trait::async_trait]
 pub trait UserValidationMethod {
     /// The type of the passkey item that can be used to display additional information about the operation to the user.
-    type PasskeyItem: TryInto<Passkey> + Send;
+    type PasskeyItem: TryInto<Passkey> + Send + Sync;
 
     /// Check for the user's presence and obtain consent for the operation. The operation may
     /// also require the user to be verified.

--- a/passkey-authenticator/src/user_validation.rs
+++ b/passkey-authenticator/src/user_validation.rs
@@ -61,10 +61,10 @@ impl MockUserValidationMethod {
     /// Sets up the mock for returning true for the verification.
     pub fn verified_user(times: usize) -> Self {
         let mut user_mock = MockUserValidationMethod::new();
+        user_mock.expect_is_presence_enabled().returning(|| true);
         user_mock
             .expect_is_verification_enabled()
-            .returning(|| Some(true))
-            .times(times);
+            .returning(|| Some(true));
         user_mock
             .expect_check_user()
             .with(

--- a/passkey-client/src/tests/mod.rs
+++ b/passkey-client/src/tests/mod.rs
@@ -54,8 +54,7 @@ fn uv_mock_with_creation(times: usize) -> MockUserValidationMethod {
     let mut user_mock = MockUserValidationMethod::new();
     user_mock
         .expect_is_verification_enabled()
-        .returning(|| Some(true))
-        .times(times + 1);
+        .returning(|| Some(true));
     user_mock
         .expect_check_user()
         .with(
@@ -70,10 +69,7 @@ fn uv_mock_with_creation(times: usize) -> MockUserValidationMethod {
             })
         })
         .times(times);
-    user_mock
-        .expect_is_presence_enabled()
-        .returning(|| true)
-        .times(1);
+    user_mock.expect_is_presence_enabled().returning(|| true);
     user_mock
 }
 

--- a/passkey-types/src/passkey.rs
+++ b/passkey-types/src/passkey.rs
@@ -20,7 +20,7 @@ use coset::CoseKey;
 /// [cred-src]: https://w3c.github.io/webauthn/#public-key-credential-source
 // TODO: Implement Zeroize on this if/when rolling our own CoseKey type
 // TODO: use `#[non_exhaustive]` here with a builder pattern for building new passkeys
-#[derive(Clone, PartialEq)]
+#[derive(Clone)]
 pub struct Passkey {
     /// The private key in COSE key format.
     ///


### PR DESCRIPTION
UP, UV and RK are currently hardcoded to true in the client, meaning that we will always create discoverable credentials, even if they aren’t actually requested.


----------------------------

Bitwarden internal tracking:
[PM-8578] based on [PM-7150]