### PR TITLE
Handle android app requests correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
 - Changed: The `Client` no longer hardcodes the RK value sent to the `Authenticator` ([#27](https://github.com/1Password/passkey-rs/pull/27)).
 - Added: The `Client` now has the ability to adjust the response for quirky relying parties
 	when a fully featured response would break their server side validation. ([#31](https://github.com/1Password/passkey-rs/pull/31))
+- ⚠ BREAKING: Added the `Origin` enum which is now the origin parameter for the following methods ([#32](https://github.com/1Password/passkey-rs/pull/27)):
+	- `Client::register` takes an `impl Into<Origin>` instead of a `&Url`
+	- `Client::authenticate` takes an `impl Into<Origin>` instead of a `&Url`
+	- `RpIdValidator::assert_domain` takes an `&Origin` instead of a `&Url`
+- ⚠ BREAKING: The collected client data will now have the android app signature as the origin when a request comes from an app directly. ([#32](https://github.com/1Password/passkey-rs/pull/27))
 
 ## Passkey v0.2.0
 ### passkey-types v0.2.0

--- a/passkey-client/Cargo.toml
+++ b/passkey-client/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 [features]
 tokio = ["dep:tokio"]
 testable = ["dep:mockall"]
+android-asset-validation = ["dep:nom"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -33,12 +34,13 @@ idna = "0.5"
 url = "2"
 coset = "0.3"
 tokio = { version = "1", features = ["sync"], optional = true }
+nom = { version = "7", features = ["alloc"], optional = true }
 
 [dev-dependencies]
 coset = "0.3"
 mockall = { version = "0.11" }
 passkey-authenticator = { path = "../passkey-authenticator", features = [
-  "tokio",
-  "testable",
+    "tokio",
+    "testable",
 ] }
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/passkey-client/src/android.rs
+++ b/passkey-client/src/android.rs
@@ -1,0 +1,157 @@
+use nom::{
+    bytes::complete::{tag, take_while_m_n},
+    character::is_hex_digit,
+    combinator::map_res,
+    multi::separated_list1,
+    IResult,
+};
+use std::{borrow::Cow, fmt::Debug, str::from_utf8};
+use url::Url;
+
+#[derive(Debug)]
+/// An Unverified asset link.
+pub struct UnverifiedAssetLink<'a> {
+    /// Application package name.
+    package_name: Cow<'a, str>,
+    /// Fingerprint to compare.
+    sha256_cert_fingerprint: Vec<u8>,
+    /// Host to lookup the well known asset link.
+    host: Cow<'a, str>,
+    /// When sourced from the application statement list or parsed from host for passkeys.
+    asset_link_url: Url,
+}
+
+impl<'a> UnverifiedAssetLink<'a> {
+    /// Create a new [`UnverifiedAssetLink`].
+    pub fn new(
+        package_name: impl Into<Cow<'a, str>>,
+        sha256_cert_fingerprint: &str,
+        host: impl Into<Cow<'a, str>>,
+        asset_link_url: Option<Url>,
+    ) -> Result<Self, ValidationError> {
+        let host = host.into();
+        let url = match asset_link_url {
+            Some(u) => u,
+            None => Url::parse(&format!("https://{host}/.well-known/assetlinks.json",))
+                .map_err(|e| ValidationError::InvalidAssetLinkUrl(e.to_string()))?,
+        };
+        valid_fingerprint(sha256_cert_fingerprint).map(|sha256_cert_fingerprint| Self {
+            package_name: package_name.into(),
+            sha256_cert_fingerprint,
+            host,
+            asset_link_url: url,
+        })
+    }
+
+    /// Fingerprint of the application's signing certificate
+    pub fn sha256_cert_fingerprint(&self) -> &[u8] {
+        self.sha256_cert_fingerprint.as_slice()
+    }
+
+    /// The application's package name
+    pub fn package_name(&self) -> &str {
+        &self.package_name
+    }
+
+    /// The host to lookup the well-known assetlinks
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+
+    /// Get the digital asset Url for validation
+    pub fn asset_link_url(&self) -> Url {
+        self.asset_link_url.clone()
+    }
+}
+
+/// Digital asset fingerprint validation error.
+#[derive(Debug)]
+pub enum ValidationError {
+    /// The fingerprint could not be parsed.
+    ParseFailed(String),
+    /// The fingerprint had an invalid length.
+    InvalidLength,
+    /// The asset link url could not be parsed.
+    InvalidAssetLinkUrl(String),
+}
+
+impl<T> From<nom::Err<nom::error::Error<T>>> for ValidationError {
+    fn from(value: nom::Err<nom::error::Error<T>>) -> Self {
+        let code_msg = value.map(|err| format!("{:?}", err.code));
+        let message = match code_msg {
+            nom::Err::Incomplete(_) => "Parsing incomplete".to_owned(),
+            nom::Err::Error(msg) => format!("Parsing error: {msg}"),
+            nom::Err::Failure(msg) => format!("Parsing failure: {msg}"),
+        };
+
+        ValidationError::ParseFailed(message)
+    }
+}
+
+/// Make sure we have an expected fingerprint. Characters have to be uppercase.
+///
+/// <https://developer.android.com/training/app-links/verify-android-applinks#fix-errors>
+/// * Having a lower case signature in assetlinks.json. The signature should be
+///   in upper case.
+pub fn valid_fingerprint(fingerprint: &str) -> Result<Vec<u8>, ValidationError> {
+    #[derive(Debug)]
+    enum HexError {
+        Utf8,
+        ParseInt,
+    }
+
+    fn parse_fingerprint(input: &[u8]) -> IResult<&[u8], Vec<u8>> {
+        separated_list1(
+            tag(":"),
+            map_res(
+                take_while_m_n(2, 2, |c| is_hex_digit(c) && !c.is_ascii_lowercase()),
+                |hex| {
+                    u8::from_str_radix(from_utf8(hex).map_err(|_| HexError::Utf8)?, 16)
+                        .map_err(|_| HexError::ParseInt)
+                },
+            ),
+        )(input)
+    }
+
+    let (left, parsed) = parse_fingerprint(fingerprint.as_bytes())?;
+
+    (left.is_empty() && parsed.len() == 32)
+        .then_some(parsed)
+        .ok_or(ValidationError::InvalidLength)
+}
+
+#[cfg(test)]
+mod test {
+    use super::valid_fingerprint;
+    use crate::ValidationError;
+
+    #[test]
+    fn check_valid_fingerprint() {
+        assert!(
+            valid_fingerprint("B3:5B:68:D5:CE:84:50:55:7C:6A:55:FD:64:B5:1F:EA:C1:10:CB:36:D6:A3:52:1C:59:48:DB:3A:38:0A:34:A9").is_ok(),
+            "Should be valid fingerprint"
+        );
+    }
+
+    #[test]
+    fn check_invalid_fingerprint_lowercase() {
+        let result = valid_fingerprint("b3:5b:68:d5:ce:84:50:55:7c:6a:55:fd:64:b5:1f:ea:c1:10:cb:36:d6:a3:52:1c:59:48:db:3a:38:0a:34:a9");
+        assert!(result.is_err(), "Should be invalid fingerprint");
+        assert!(matches!(result, Err(ValidationError::ParseFailed(..))))
+    }
+
+    #[test]
+    fn check_invalid_fingerprint_length() {
+        let result = valid_fingerprint("B3:5B:68:D5:CE:84:50:55:7C:6A:55");
+        assert!(result.is_err(), "Should be invalid fingerprint");
+        assert!(matches!(result, Err(ValidationError::InvalidLength)))
+    }
+
+    #[test]
+    fn check_invalid_fingerprint_non_hex() {
+        assert!(
+            valid_fingerprint("B3:5B:68:X5:CE:84:50:55:7C:6A:55:FD:64:B5:1F:EA:C1:10:CB:36:D6:A3:52:1C:59:48:DB:3A:38:0A:34:A9").is_err(),
+            "Should be valid fingerprint"
+        );
+    }
+}

--- a/passkey-client/src/lib.rs
+++ b/passkey-client/src/lib.rs
@@ -34,6 +34,12 @@ use url::Url;
 mod quirks;
 use quirks::QuirkyRp;
 
+#[cfg(feature = "android-asset-validation")]
+mod android;
+
+#[cfg(feature = "android-asset-validation")]
+pub use self::android::{valid_fingerprint, UnverifiedAssetLink, ValidationError};
+
 #[cfg(test)]
 mod tests;
 

--- a/passkey-client/src/lib.rs
+++ b/passkey-client/src/lib.rs
@@ -14,7 +14,7 @@
 //! [version]: https://img.shields.io/crates/v/passkey-client?logo=rust&style=flat
 //! [documentation]: https://img.shields.io/docsrs/passkey-client/latest?logo=docs.rs&style=flat
 //! [Webauthn]: https://w3c.github.io/webauthn/
-use std::borrow::Cow;
+use std::{borrow::Cow, fmt::Display};
 
 use ciborium::{cbor, value::Value};
 use coset::{iana::EnumI64, Algorithm};
@@ -98,6 +98,43 @@ fn decode_host(host: &str) -> Option<Cow<str>> {
     }
 }
 
+/// The origin of a WebAuthn request.
+pub enum Origin<'a> {
+    /// A Url, meant for a request in the web browser.
+    Web(Cow<'a, Url>),
+    /// An android digital asset fingerprint.
+    /// Meant for a request coming from an android application.
+    #[cfg(feature = "android-asset-validation")]
+    Android(UnverifiedAssetLink<'a>),
+}
+
+impl From<Url> for Origin<'_> {
+    fn from(value: Url) -> Self {
+        Origin::Web(Cow::Owned(value))
+    }
+}
+
+impl<'a> From<&'a Url> for Origin<'a> {
+    fn from(value: &'a Url) -> Self {
+        Origin::Web(Cow::Borrowed(value))
+    }
+}
+
+impl Display for Origin<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Origin::Web(url) => write!(f, "{}", url.as_str().trim_end_matches('/')),
+            Origin::Android(target_link) => {
+                write!(
+                    f,
+                    "android:apk-key-hash:{}",
+                    encoding::base64url(target_link.sha256_cert_fingerprint())
+                )
+            }
+        }
+    }
+}
+
 /// A `Client` represents a Webauthn client. Users of this struct should supply a
 /// [`CredentialStore`], a [`UserValidationMethod`] and, optionally, an implementation of
 /// [`public_suffix::EffectiveTLDProvider`].
@@ -174,10 +211,12 @@ where
     /// Returns either a [`webauthn::CreatedPublicKeyCredential`] on success or some [`WebauthnError`]
     pub async fn register(
         &mut self,
-        origin: &Url,
+        origin: impl Into<Origin<'_>>,
         request: webauthn::CredentialCreationOptions,
         client_data_hash: Option<Vec<u8>>,
     ) -> Result<webauthn::CreatedPublicKeyCredential, WebauthnError> {
+        let origin = origin.into();
+
         // extract inner value of request as there is nothing else of value directly in CredentialCreationOptions
         let request = request.public_key;
         let auth_info = self.authenticator.get_info();
@@ -196,12 +235,12 @@ where
 
         let rp_id = self
             .rp_id_verifier
-            .assert_domain(origin, request.rp.id.as_deref())?;
+            .assert_domain(&origin, request.rp.id.as_deref())?;
 
         let collected_client_data = webauthn::CollectedClientData {
             ty: webauthn::ClientDataType::Create,
             challenge: encoding::base64url(&request.challenge),
-            origin: origin.as_str().trim_end_matches('/').to_owned(),
+            origin: origin.to_string(),
             cross_origin: None,
             unknown_keys: Default::default(),
         };
@@ -306,10 +345,12 @@ where
     /// Returns either an [`webauthn::AuthenticatedPublicKeyCredential`] on success or some [`WebauthnError`].
     pub async fn authenticate(
         &mut self,
-        origin: &Url,
+        origin: impl Into<Origin<'_>>,
         request: webauthn::CredentialRequestOptions,
         client_data_hash: Option<Vec<u8>>,
     ) -> Result<webauthn::AuthenticatedPublicKeyCredential, WebauthnError> {
+        let origin = origin.into();
+
         // extract inner value of request as there is nothing else of value directly in CredentialRequestOptions
         let request = request.public_key;
 
@@ -322,12 +363,12 @@ where
 
         let rp_id = self
             .rp_id_verifier
-            .assert_domain(origin, request.rp_id.as_deref())?;
+            .assert_domain(&origin, request.rp_id.as_deref())?;
 
         let collected_client_data = webauthn::CollectedClientData {
             ty: webauthn::ClientDataType::Get,
             challenge: encoding::base64url(&request.challenge),
-            origin: origin.as_str().trim_end_matches('/').to_owned(),
+            origin: origin.to_string(),
             cross_origin: None, //Some(false),
             unknown_keys: Default::default(),
         };
@@ -456,6 +497,18 @@ where
     /// Returns the effective domain on success or some [`WebauthnError`]
     pub fn assert_domain<'a>(
         &self,
+        origin: &'a Origin,
+        rp_id: Option<&'a str>,
+    ) -> Result<&'a str, WebauthnError> {
+        match origin {
+            Origin::Web(url) => self.assert_web_rp_id(url, rp_id),
+            #[cfg(feature = "android-asset-validation")]
+            Origin::Android(unverified) => self.assert_android_rp_id(unverified, rp_id),
+        }
+    }
+
+    fn assert_web_rp_id<'a>(
+        &self,
         origin: &'a Url,
         rp_id: Option<&'a str>,
     ) -> Result<&'a str, WebauthnError> {
@@ -493,6 +546,37 @@ where
         }
 
         Ok(effective_domain)
+    }
+
+    #[cfg(feature = "android-asset-validation")]
+    fn assert_android_rp_id<'a>(
+        &self,
+        target_link: &'a UnverifiedAssetLink,
+        rp_id: Option<&'a str>,
+    ) -> Result<&'a str, WebauthnError> {
+        let mut effective_rp_id = target_link.host();
+
+        if let Some(rp_id) = rp_id {
+            // subset from assert_web_rp_id
+            if !effective_rp_id.ends_with(rp_id) {
+                return Err(WebauthnError::OriginRpMissmatch);
+            }
+            effective_rp_id = rp_id;
+        }
+
+        if decode_host(effective_rp_id)
+            .as_ref()
+            .and_then(|s| self.tld_provider.effective_tld_plus_one(s).ok())
+            .is_none()
+        {
+            return Err(WebauthnError::InvalidRpId);
+        }
+
+        // TODO: Find an ergonomic and caching friendly way to fetch the remote
+        // assetlinks and validate them here.
+        // https://github.com/1Password/passkey-rs/issues/13
+
+        Ok(effective_rp_id)
     }
 }
 

--- a/passkey-client/src/tests/mod.rs
+++ b/passkey-client/src/tests/mod.rs
@@ -97,7 +97,7 @@ async fn create_and_authenticate() {
         public_key: good_credential_request_options(credential_id),
     };
     client
-        .authenticate(&origin, auth_options, None)
+        .authenticate(origin, auth_options, None)
         .await
         .expect("failed to authenticate with freshly created credential");
 }
@@ -132,7 +132,7 @@ async fn create_and_authenticate_with_origin_subdomain() {
         public_key: good_credential_request_options(cred.raw_id),
     };
     let res = client
-        .authenticate(&origin, auth_options, None)
+        .authenticate(origin, auth_options, None)
         .await
         .expect("failed to authenticate with freshly created credential");
     let att_obj = ctap2::AuthenticatorData::from_slice(&res.response.authenticator_data)
@@ -179,7 +179,7 @@ async fn create_and_authenticate_without_rp_id() {
         },
     };
     let res = client
-        .authenticate(&origin, auth_options, None)
+        .authenticate(origin, auth_options, None)
         .await
         .expect("failed to authenticate with freshly created credential");
     let att_obj = ctap2::AuthenticatorData::from_slice(&res.response.authenticator_data)
@@ -214,7 +214,7 @@ async fn create_and_authenticate_without_cred_params() {
         public_key: good_credential_request_options(credential_id),
     };
     client
-        .authenticate(&origin, auth_options, None)
+        .authenticate(origin, auth_options, None)
         .await
         .expect("failed to authenticate with freshly created credential");
 }
@@ -223,26 +223,26 @@ async fn create_and_authenticate_without_cred_params() {
 fn validate_rp_id() -> Result<(), ParseError> {
     let client = RpIdVerifier::new(public_suffix::DEFAULT_PROVIDER);
 
-    let example = "https://example.com".parse()?;
+    let example = Url::parse("https://example.com")?.into();
     let com_tld = client.assert_domain(&example, Some("com"));
     assert_eq!(com_tld, Err(WebauthnError::InvalidRpId));
 
-    let example_dots = "https://example...com".parse()?;
+    let example_dots = Url::parse("https://example...com")?.into();
     let bunch_of_dots = client.assert_domain(&example_dots, Some("...com"));
     assert_eq!(bunch_of_dots, Err(WebauthnError::InvalidRpId));
 
-    let future = "https://www.future.1password.com".parse()?;
+    let future = Url::parse("https://www.future.1password.com")?.into();
     let sub_domain_ignored = client.assert_domain(&future, Some("future.1password.com"));
     assert_eq!(sub_domain_ignored, Ok("future.1password.com"));
 
     let use_effective_domain = client.assert_domain(&future, None);
     assert_eq!(use_effective_domain, Ok("www.future.1password.com"));
 
-    let not_protected = "http://example.com".parse()?;
+    let not_protected = Url::parse("http://example.com")?.into();
     let not_https = client.assert_domain(&not_protected, Some("example.com"));
     assert_eq!(not_https, Err(WebauthnError::UnprotectedOrigin));
 
-    let localhost = "http://localhost:8080".parse()?;
+    let localhost = Url::parse("http://localhost:8080")?.into();
     let should_still_match = client.assert_domain(&localhost, Some("example.com"));
     assert_eq!(should_still_match, Err(WebauthnError::OriginRpMissmatch));
 
@@ -286,7 +286,7 @@ fn validate_domain_with_private_list_provider() -> Result<(), ParseError> {
     // Notice that, in this test, this is a legitimate origin/rp_id combination
     // We assert that this produces an error to prove that we are indeed using our
     // BrokenTLDProvider which always returns Err() regardless of the TLD.
-    let origin = "https://www.future.1password.com".parse()?;
+    let origin = Url::parse("https://www.future.1password.com")?.into();
     let rp_id = "future.1password.com";
     let result = client.assert_domain(&origin, Some(rp_id));
     assert_eq!(result, Err(WebauthnError::InvalidRpId));
@@ -351,7 +351,7 @@ async fn client_register_triggers_uv_when_uv_is_required() {
 
     // Act & Assert
     client
-        .register(&origin, options, None)
+        .register(origin, options, None)
         .await
         .expect("failed to register with options");
 }
@@ -378,7 +378,7 @@ async fn client_register_does_not_trigger_uv_when_uv_is_discouraged() {
 
     // Act & Assert
     client
-        .register(&origin, options, None)
+        .register(origin, options, None)
         .await
         .expect("failed to register with options");
 }


### PR DESCRIPTION
Android requires the origin to follow the following pattern: `android:apk-key-hash:<HASH>`. See [here](https://developer.android.com/identity/sign-in/credential-manager#verify-origin).

This PR refactors the `origin` input to a wrapper type which can be converted to from a new `UnverifiedAssetLink` type for android as well as from `Url`s for web and apple. This type will then create the request origin accordingly.