### PR TITLE
Support prf already hashed extension (PRF#6)

### DIFF
--- a/passkey-client/src/lib.rs
+++ b/passkey-client/src/lib.rs
@@ -68,6 +68,8 @@ pub enum WebauthnError {
     NotSupportedError,
     /// The string did not match the expected pattern.
     SyntaxError,
+    /// The input failed validation
+    ValidationError,
 }
 
 impl WebauthnError {


### PR DESCRIPTION
This PR follows on #37. It implements an unofficial variant of the PRF extension where its inputs are already hashed according to the `sha256("WebAuthn PRF" || salt)` format. This extension might appear on Android and must be used when mapping from Apple's [authentication services](https://developer.apple.com/documentation/authenticationservices/asauthorizationpublickeycredentialprfassertioninput-swift.struct).