### PR TITLE
Add github action to catch badly formated docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,22 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           components: rustfmt
-      - run: rustup run ${{ matrix.rust}} cargo fmt --all -- --check
+      - run: rustup run ${{ matrix.rust }} cargo fmt --all -- --check
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+      - run: RUSTDOCFLAGS="-D warnings " rustup run ${{ matrix.rust }} cargo doc --workspace --no-deps --all-features
 
   test:
     name: Test
@@ -56,7 +71,7 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
-      - run: rustup run ${{ matrix.rust }} cargo test 
+      - run: rustup run ${{ matrix.rust }} cargo test
 
   typeshare:
     name: Typeshare

--- a/passkey-types/src/ctap2/get_assertion.rs
+++ b/passkey-types/src/ctap2/get_assertion.rs
@@ -10,7 +10,10 @@ use crate::{
 pub use crate::ctap2::make_credential::Options;
 
 #[cfg(doc)]
-use crate::webauthn::{CollectedClientData, PublicKeyCredentialRequestOptions};
+use {
+    crate::webauthn::{CollectedClientData, PublicKeyCredentialRequestOptions},
+    ciborium::Value,
+};
 
 use super::extensions::{AuthenticatorPrfGetOutputs, AuthenticatorPrfInputs, HmacGetSecretInput};
 

--- a/passkey-types/src/ctap2/make_credential.rs
+++ b/passkey-types/src/ctap2/make_credential.rs
@@ -5,8 +5,11 @@ use serde::{Deserialize, Serialize};
 use crate::{ctap2::AuthenticatorData, webauthn, Bytes};
 
 #[cfg(doc)]
-use crate::webauthn::{
-    CollectedClientData, PublicKeyCredentialCreationOptions, PublicKeyCredentialDescriptor,
+use {
+    crate::webauthn::{
+        CollectedClientData, PublicKeyCredentialCreationOptions, PublicKeyCredentialDescriptor,
+    },
+    ciborium::value::Value,
 };
 
 use super::extensions::{AuthenticatorPrfInputs, AuthenticatorPrfMakeOutputs, HmacGetSecretInput};


### PR DESCRIPTION
This fixes a doc comment that links to `ciborium::value::Value` but that no longer gets imported in `get-assertion`. This wasn't caught in CI so a job was added to catch that going forward.