### PR TITLE
Change the user-handle to be dependent on the store info discoverability

### DIFF
--- a/passkey-authenticator/src/authenticator/make_credential.rs
+++ b/passkey-authenticator/src/authenticator/make_credential.rs
@@ -110,11 +110,17 @@ where
         // credential.
         let CoseKeyPair { public, private } = CoseKeyPair::from_secret_key(&private_key, algorithm);
 
+        let store_info = self.store.get_info().await;
+
+        let is_passkey_rk = store_info
+            .discoverability
+            .is_passkey_discoverable(input.options.rk);
+
         let passkey = Passkey {
             key: private,
             rp_id: input.rp.id.clone(),
             credential_id: credential_id.into(),
-            user_handle: input.options.rk.then_some(input.user.id.clone()),
+            user_handle: is_passkey_rk.then(|| input.user.id.clone()),
             counter: self.make_credentials_with_signature_counter.then_some(0),
             extensions: extensions.credential,
         };

--- a/passkey-authenticator/src/credential_store.rs
+++ b/passkey-authenticator/src/credential_store.rs
@@ -33,6 +33,17 @@ pub enum DiscoverabilitySupport {
     ForcedDiscoverable,
 }
 
+impl DiscoverabilitySupport {
+    /// Helper method to determine if the store created a discoverable credential or not.
+    pub fn is_passkey_discoverable(&self, rk_input: bool) -> bool {
+        match self {
+            DiscoverabilitySupport::Full => rk_input,
+            DiscoverabilitySupport::OnlyNonDiscoverable => false,
+            DiscoverabilitySupport::ForcedDiscoverable => true,
+        }
+    }
+}
+
 /// Use this on a type that enables storage and fetching of credentials
 #[async_trait::async_trait]
 pub trait CredentialStore {

--- a/passkey-client/src/extensions.rs
+++ b/passkey-client/src/extensions.rs
@@ -10,9 +10,7 @@
 //! [credprops]: https://w3c.github.io/webauthn/#sctn-authenticator-credential-properties-extension
 //! [prf]: https://w3c.github.io/webauthn/#prf-extension
 
-use passkey_authenticator::{
-    CredentialStore, DiscoverabilitySupport, StoreInfo, UserValidationMethod,
-};
+use passkey_authenticator::{CredentialStore, StoreInfo, UserValidationMethod};
 use passkey_types::{
     ctap2::{get_assertion, get_info, make_credential},
     webauthn::{
@@ -53,11 +51,7 @@ where
     ) -> AuthenticationExtensionsClientOutputs {
         let cred_props_requested = request.and_then(|ext| ext.cred_props) == Some(true);
         let cred_props = if cred_props_requested {
-            let discoverable = match store_info.discoverability {
-                DiscoverabilitySupport::Full => rk,
-                DiscoverabilitySupport::OnlyNonDiscoverable => false,
-                DiscoverabilitySupport::ForcedDiscoverable => true,
-            };
+            let discoverable = store_info.discoverability.is_passkey_discoverable(rk);
 
             Some(CredentialPropertiesOutput {
                 discoverable: Some(discoverable),


### PR DESCRIPTION
With added support for non discoverable credentials in #29, the userhandle was only added if the request included `rk=true` and ignored the store's discoverability support. This mixes the two together.