### PR TITLE
Change make_credential::Response order to follow CTAP2.1

### DIFF
--- a/passkey-authenticator/src/authenticator/make_credential.rs
+++ b/passkey-authenticator/src/authenticator/make_credential.rs
@@ -144,9 +144,9 @@ where
             .set_make_credential_extensions(extensions.signed)?;
 
         let response = Response {
-            auth_data,
             fmt: "None".into(),
-            att_stmt: vec![0xa0].into(), // CBOR equivalent to empty map
+            auth_data,
+            att_stmt: coset::cbor::value::Value::Map(vec![]),
             ep_att: None,
             large_blob_key: None,
             unsigned_extension_outputs: extensions.unsigned,

--- a/passkey-types/src/ctap2/make_credential.rs
+++ b/passkey-types/src/ctap2/make_credential.rs
@@ -258,13 +258,13 @@ serde_workaround! {
     /// Upon successful creation of a credential, the authenticator returns an attestation object.
     #[derive(Debug)]
     pub struct Response {
-        /// The authenticator data object
-        #[serde(rename = 0x01)]
-        pub auth_data: AuthenticatorData,
-
         /// The attestation statement format identifier
-        #[serde(rename = 0x02)]
+        #[serde(rename = 0x01)]
         pub fmt: String,
+
+        /// The authenticator data object
+        #[serde(rename = 0x02)]
+        pub auth_data: AuthenticatorData,
 
         /// The attestation statement, whose format is identified by the "fmt" object member.
         /// The client treats it as an opaque object.


### PR DESCRIPTION
Turns out we were following [CTAP2.0](https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#authenticatorMakeCredential) at the time of authoring passkey-types while this order was changed in [CTAP2.1](https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#sctn-discoverable). This was changed due do a mismatch between security keys and the spec. The spec changed to follow what security keys were doing.