### PR TITLE
Add cargo semver-checks to gitub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,14 @@ jobs:
           components: rustfmt
       - run: rustup run ${{ matrix.rust }} cargo fmt --all -- --check
 
+  semver-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
This adds a github action that tests if there's a breaking change in the public API and if there should be a major or minor semver bump in the crate.

Uses [`cargo-semver-checks`](https://github.com/obi1kenobi/cargo-semver-checks)