### PR TITLE
Add configuration option for new credential ID length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Added: support for controlling generated credential's ID length to passkey-authenticator ([#49](https://github.com/1Password/passkey-rs/pull/49))
 
 ## Passkey v0.3.0
 ### passkey-authenticator v0.3.0

--- a/passkey-authenticator/src/authenticator/make_credential.rs
+++ b/passkey-authenticator/src/authenticator/make_credential.rs
@@ -91,12 +91,7 @@ where
         //    error.
 
         // 9. Generate a new credential key pair for the algorithm specified.
-        let credential_id: Vec<u8> = {
-            use rand::RngCore;
-            let mut data = vec![0u8; 16];
-            rand::thread_rng().fill_bytes(&mut data);
-            data
-        };
+        let credential_id = passkey_types::rand::random_vec(self.credential_id_length.into());
 
         let private_key = {
             let mut rng = rand::thread_rng();

--- a/passkey-authenticator/src/lib.rs
+++ b/passkey-authenticator/src/lib.rs
@@ -42,7 +42,7 @@ use p256::{
 use passkey_types::{ctap2::Ctap2Error, Bytes};
 
 pub use self::{
-    authenticator::{extensions, Authenticator},
+    authenticator::{extensions, Authenticator, CredentialIdLength},
     credential_store::{CredentialStore, DiscoverabilitySupport, MemoryStore, StoreInfo},
     ctap2::Ctap2Api,
     u2f::U2fApi,


### PR DESCRIPTION
This PR adds support for authenticators built on-top of `passkey-rs` to control what length user handle/credentialId they make for later storage in the passkey provider. Providers may want to randomize or otherwise change this value to prevent authenticator fingerprinting based on well-known lengths.