### PR TITLE
handle error for `store.find_credentials`

### DIFF
--- a/passkey-authenticator/src/authenticator/make_credential.rs
+++ b/passkey-authenticator/src/authenticator/make_credential.rs
@@ -33,14 +33,13 @@ where
             .as_ref()
             .filter(|list| !list.is_empty())
             .is_some()
-        {
-            if !self
+            && !self
                 .store()
                 .find_credentials(input.exclude_list.as_deref(), &input.rp.id)
-                .await?.is_empty()
-            {
-                return Err(Ctap2Error::CredentialExcluded.into());
-            }
+                .await?
+                .is_empty()
+        {
+            return Err(Ctap2Error::CredentialExcluded.into());
         }
 
         // 2. If the pubKeyCredParams parameter does not contain a valid COSEAlgorithmIdentifier

--- a/passkey-authenticator/src/authenticator/make_credential.rs
+++ b/passkey-authenticator/src/authenticator/make_credential.rs
@@ -34,11 +34,10 @@ where
             .filter(|list| !list.is_empty())
             .is_some()
         {
-            if let Ok(false) = self
+            if !self
                 .store()
                 .find_credentials(input.exclude_list.as_deref(), &input.rp.id)
-                .await
-                .map(|creds| creds.is_empty())
+                .await?.is_empty()
             {
                 return Err(Ctap2Error::CredentialExcluded.into());
             }


### PR DESCRIPTION
Currently the error returned by `store.find_credentials` is silently ignored.

This PR returns the error to the caller if it happens, and also improves read-ability.