### PR TITLE
Pin Rust and CI image OS version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ name: CI
 jobs:
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         rust:
@@ -27,7 +27,7 @@ jobs:
 
   fmt:
     name: Rustfmt
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         rust:
@@ -43,7 +43,7 @@ jobs:
       - run: rustup run ${{ matrix.rust }} cargo fmt --all -- --check
 
   semver-checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,7 +52,7 @@ jobs:
 
   docs:
     name: Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         rust:
@@ -67,7 +67,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         rust:
@@ -83,7 +83,7 @@ jobs:
 
   typeshare:
     name: Typeshare
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         rust:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2024"
 keywords = ["ctap", "fido2", "passkey", "passwordless", "webauthn"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/1Password/passkey-rs"
+rust-version = "1.85.1"
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/passkey-authenticator/Cargo.toml
+++ b/passkey-authenticator/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 name = "passkey-authenticator"
 readme = "README.md"
 repository.workspace = true
+rust-version.workspace = true
 version = "0.5.0"
 
 [lints]

--- a/passkey-client/Cargo.toml
+++ b/passkey-client/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 name = "passkey-client"
 readme = "README.md"
 repository.workspace = true
+rust-version.workspace = true
 version = "0.5.0"
 
 [lints]

--- a/passkey-transports/Cargo.toml
+++ b/passkey-transports/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 name = "passkey-transports"
 readme = "README.md"
 repository.workspace = true
+rust-version.workspace = true
 version = "0.1.0"
 
 

--- a/passkey-types/Cargo.toml
+++ b/passkey-types/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 name = "passkey-types"
 readme = "README.md"
 repository.workspace = true
+rust-version.workspace = true
 version = "0.5.0"
 
 [lints]

--- a/passkey/Cargo.toml
+++ b/passkey/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 name = "passkey"
 readme = "../README.md"
 repository.workspace = true
+rust-version.workspace = true
 version = "0.5.0"
 
 [lints]

--- a/public-suffix/Cargo.toml
+++ b/public-suffix/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 name = "public-suffix"
 readme = "README.md"
 repository.workspace = true
+rust-version.workspace = true
 version = "0.1.3"
 
 [lints]


### PR DESCRIPTION
This sets an MSRV of 1.85.1 and pins the Rust toolchain to that version. 1.85.1 was somewhat arbitrarily chosen because it is the latest [patch] release that supports 2024 edition.

It also pins the GitHub Actions runner version to Ubuntu 24.04. (`ubuntu-latest` has pointed to 24.04 [since early 2025](https://github.com/actions/runner-images/issues/10636).)

By policy, in Bitwarden's fork, we also pin the action versions with hashes rather than tags, but I didn't know if you wanted to force our policies on this project or if tag pinning is OK with you, so I omitted that for now.