### PR TITLE
Add more context to check_user()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- ⚠ BREAKING: The `UserValidationMethod` trait has been updated to use `UiHint`
+  to give the implementation more information about the request, which can be used
+  to decide whether additional validations are needed. To reflect this, the
+  `UserValidationMethod` trait now also returns which validations were performed.
+
 ## Passkey v0.5.0
 
 - Migrate project to Rust 2024 edition

--- a/passkey-authenticator/src/authenticator.rs
+++ b/passkey-authenticator/src/authenticator.rs
@@ -4,7 +4,7 @@ use passkey_types::{
     webauthn,
 };
 
-use crate::{CredentialStore, UserValidationMethod};
+use crate::{CredentialStore, UserValidationMethod, user_validation::UiHint};
 
 pub mod extensions;
 mod get_assertion;
@@ -201,8 +201,8 @@ where
     ///            CTAP2_ERR_OPERATION_DENIED error.
     async fn check_user(
         &self,
+        hint: UiHint<'_, <U as UserValidationMethod>::PasskeyItem>,
         options: &passkey_types::ctap2::make_credential::Options,
-        credential: Option<&<U as UserValidationMethod>::PasskeyItem>,
     ) -> Result<Flags, Ctap2Error> {
         if options.uv && self.user_validation.is_verification_enabled() != Some(true) {
             return Err(Ctap2Error::UnsupportedOption);
@@ -210,7 +210,7 @@ where
 
         let check_result = self
             .user_validation
-            .check_user(credential, options.up, options.uv)
+            .check_user(hint, options.up, options.uv)
             .await?;
 
         if options.up && !check_result.presence {

--- a/passkey-authenticator/src/authenticator/get_assertion.rs
+++ b/passkey-authenticator/src/authenticator/get_assertion.rs
@@ -7,7 +7,10 @@ use passkey_types::{
     webauthn::PublicKeyCredentialUserEntity,
 };
 
-use crate::{Authenticator, CredentialStore, UserValidationMethod, private_key_from_cose_key};
+use crate::{
+    Authenticator, CredentialStore, UserValidationMethod, private_key_from_cose_key,
+    user_validation::UiHint,
+};
 
 impl<S, U> Authenticator<S, U>
 where
@@ -70,9 +73,11 @@ where
         // 7. Collect user consent if required. This step MUST happen before the following steps due
         //    to privacy reasons (i.e., authenticator cannot disclose existence of a credential
         //    until the user interacted with the device):
-        let flags = self
-            .check_user(&input.options, maybe_credential.as_ref().ok())
-            .await?;
+        let hint = match &maybe_credential {
+            Ok(credential) => UiHint::RequestExistingCredential(credential),
+            Err(_) => UiHint::InformNoCredentialsFound,
+        };
+        let flags = self.check_user(hint, &input.options).await?;
 
         // 8. If no credentials were located in step 1, return CTAP2_ERR_NO_CREDENTIALS.
         let mut credential = maybe_credential?

--- a/passkey-authenticator/src/authenticator/tests.rs
+++ b/passkey-authenticator/src/authenticator/tests.rs
@@ -1,6 +1,8 @@
 use passkey_types::ctap2::{Aaguid, Flags};
 
-use crate::{Authenticator, CredentialIdLength, MockUserValidationMethod, UserCheck};
+use crate::{
+    Authenticator, CredentialIdLength, MockUserValidationMethod, UserCheck, user_validation::UiHint,
+};
 
 #[tokio::test]
 async fn check_user_does_not_check_up_or_uv_when_not_requested() {
@@ -31,7 +33,10 @@ async fn check_user_does_not_check_up_or_uv_when_not_requested() {
     };
 
     // Act
-    let result = authenticator.check_user(&options, None).await.unwrap();
+    let result = authenticator
+        .check_user(UiHint::InformNoCredentialsFound, &options)
+        .await
+        .unwrap();
 
     // Assert
     assert_eq!(result, Flags::empty());
@@ -66,7 +71,10 @@ async fn check_user_checks_up_when_requested() {
     };
 
     // Act
-    let result = authenticator.check_user(&options, None).await.unwrap();
+    let result = authenticator
+        .check_user(UiHint::InformNoCredentialsFound, &options)
+        .await
+        .unwrap();
 
     // Assert
     assert_eq!(result, Flags::UP);
@@ -104,7 +112,10 @@ async fn check_user_checks_uv_when_requested() {
     };
 
     // Act
-    let result = authenticator.check_user(&options, None).await.unwrap();
+    let result = authenticator
+        .check_user(UiHint::InformNoCredentialsFound, &options)
+        .await
+        .unwrap();
 
     // Assert
     assert_eq!(result, Flags::UP | Flags::UV);
@@ -139,7 +150,9 @@ async fn check_user_returns_operation_denied_when_up_was_requested_but_not_retur
     };
 
     // Act
-    let result = authenticator.check_user(&options, None).await;
+    let result = authenticator
+        .check_user(UiHint::InformNoCredentialsFound, &options)
+        .await;
 
     // Assert
     assert_eq!(
@@ -180,7 +193,9 @@ async fn check_user_returns_operation_denied_when_uv_was_requested_but_not_retur
     };
 
     // Act
-    let result = authenticator.check_user(&options, None).await;
+    let result = authenticator
+        .check_user(UiHint::InformNoCredentialsFound, &options)
+        .await;
 
     // Assert
     assert_eq!(
@@ -207,7 +222,9 @@ async fn check_user_returns_unsupported_option_when_uv_was_requested_but_is_not_
     };
 
     // Act
-    let result = authenticator.check_user(&options, None).await;
+    let result = authenticator
+        .check_user(UiHint::InformNoCredentialsFound, &options)
+        .await;
 
     // Assert
     assert_eq!(
@@ -249,7 +266,10 @@ async fn check_user_returns_up_and_uv_flags_when_neither_up_or_uv_was_requested_
     };
 
     // Act
-    let result = authenticator.check_user(&options, None).await.unwrap();
+    let result = authenticator
+        .check_user(UiHint::InformNoCredentialsFound, &options)
+        .await
+        .unwrap();
 
     // Assert
     assert_eq!(result, Flags::UP | Flags::UV);

--- a/passkey-authenticator/src/lib.rs
+++ b/passkey-authenticator/src/lib.rs
@@ -46,7 +46,7 @@ pub use self::{
     credential_store::{CredentialStore, DiscoverabilitySupport, MemoryStore, StoreInfo},
     ctap2::Ctap2Api,
     u2f::U2fApi,
-    user_validation::{UserCheck, UserValidationMethod},
+    user_validation::{UiHint, UserCheck, UserValidationMethod},
 };
 
 #[cfg(any(test, feature = "testable"))]

--- a/passkey-authenticator/src/user_validation.rs
+++ b/passkey-authenticator/src/user_validation.rs
@@ -1,7 +1,32 @@
-use passkey_types::{Passkey, ctap2::Ctap2Error};
+use passkey_types::{
+    Passkey,
+    ctap2::{
+        Ctap2Error,
+        make_credential::{PublicKeyCredentialRpEntity, PublicKeyCredentialUserEntity},
+    },
+};
 
 #[cfg(doc)]
 use crate::Authenticator;
+
+/// Additional information that can be displayed to the user if the authenticator has a display.
+#[derive(Debug, Clone, PartialEq)]
+pub enum UiHint<'a, P> {
+    /// Inform the user that the operation cannot be completed because the user already has a credential registered.
+    InformExcludedCredentialFound(&'a P),
+
+    /// Inform the user that the operation cannot be completed because the user has no matching credentials registered.
+    InformNoCredentialsFound,
+
+    /// Request permission to save the credential in this object.
+    RequestNewCredential(
+        &'a PublicKeyCredentialUserEntity,
+        &'a PublicKeyCredentialRpEntity,
+    ),
+
+    /// Request permission to use the existing credential in this object.
+    RequestExistingCredential(&'a P),
+}
 
 /// The result of a user validation check.
 #[derive(Clone, Copy, PartialEq)]
@@ -23,12 +48,12 @@ pub trait UserValidationMethod {
     /// Check for the user's presence and obtain consent for the operation. The operation may
     /// also require the user to be verified.
     ///
-    /// * `crdential` - Can be used to display additional information about the operation to the user.
+    /// * `hint` - Can be used to display additional information about the operation to the user.
     /// * `presence` - Indicates whether the user's presence is required.
     /// * `verification` - Indicates whether the user should be verified.
     async fn check_user<'a>(
         &self,
-        credential: Option<&'a Self::PasskeyItem>,
+        hint: UiHint<'a, Self::PasskeyItem>,
         presence: bool,
         verification: bool,
     ) -> Result<UserCheck, Ctap2Error>;
@@ -53,6 +78,17 @@ pub trait UserValidationMethod {
     /// If a device is capable of verifying the user within itself as well as able to do Client PIN,
     ///  it will return both `Some` and the Client PIN option.
     fn is_verification_enabled(&self) -> Option<bool>;
+}
+
+/// A version of the [`UiHint`] that uses a [`Passkey`] as the passkey item, is not tied to any specific lifetime,
+/// and does not verify new passkey items which contain new random data that the tests cannot know about beforehand.
+#[cfg(any(test, feature = "testable"))]
+#[derive(Debug, Clone)]
+pub enum MockUiHint {
+    InformExcludedCredentialFound(Passkey),
+    InformNoCredentialsFound,
+    RequestNewCredential(PublicKeyCredentialUserEntity, PublicKeyCredentialRpEntity),
+    RequestExistingCredential(Passkey),
 }
 
 #[cfg(any(test, feature = "testable"))]
@@ -84,14 +120,36 @@ impl MockUserValidationMethod {
     }
 
     /// Sets up the mock for returning true for the verification.
-    pub fn verified_user_with_credential(times: usize, credential: Passkey) -> Self {
+    pub fn verified_user_with_hint(times: usize, expected_hint: MockUiHint) -> Self {
         let mut user_mock = MockUserValidationMethod::new();
         user_mock
             .expect_is_verification_enabled()
-            .returning(|| Some(true));
+            .returning(|| Some(true))
+            .times(..);
+        user_mock
+            .expect_is_presence_enabled()
+            .returning(|| true)
+            .times(..);
         user_mock
             .expect_check_user()
-            .withf(move |cred, up, uv| cred == &Some(&credential) && *up && *uv)
+            .withf(move |actual_hint, presence, verification| {
+                *presence
+                    && *verification
+                    && match &expected_hint {
+                        MockUiHint::InformExcludedCredentialFound(p) => {
+                            actual_hint == &UiHint::InformExcludedCredentialFound(p)
+                        }
+                        MockUiHint::InformNoCredentialsFound => {
+                            matches!(actual_hint, UiHint::InformNoCredentialsFound)
+                        }
+                        MockUiHint::RequestNewCredential(user, rp) => {
+                            actual_hint == &UiHint::RequestNewCredential(user, rp)
+                        }
+                        MockUiHint::RequestExistingCredential(p) => {
+                            actual_hint == &UiHint::RequestExistingCredential(p)
+                        }
+                    }
+            })
             .returning(|_, _, _| {
                 Ok(UserCheck {
                     presence: true,

--- a/passkey-types/src/ctap2/make_credential.rs
+++ b/passkey-types/src/ctap2/make_credential.rs
@@ -93,7 +93,7 @@ serde_workaround! {
 ///
 /// [WebAuthn]: https://w3c.github.io/webauthn/#dictdef-publickeycredentialrpentity
 /// [CTAP2]: https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#authenticatorMakeCredential
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct PublicKeyCredentialRpEntity {
     /// The domain of the relying party
     pub id: String,
@@ -103,7 +103,7 @@ pub struct PublicKeyCredentialRpEntity {
 }
 
 /// This is a copy of [`webauthn::PublicKeyCredentialUserEntity`] with differing optional fields.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct PublicKeyCredentialUserEntity {
     /// The ID of the user
     pub id: Bytes,
@@ -173,7 +173,7 @@ impl TryFrom<webauthn::PublicKeyCredentialRpEntity> for PublicKeyCredentialRpEnt
 }
 
 /// The options that control how an authenticator will behave.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Options {
     /// Specifies whether this credential is to be discoverable or not.
     #[serde(default)]

--- a/passkey/examples/usage.rs
+++ b/passkey/examples/usage.rs
@@ -1,6 +1,6 @@
 //! Sample App for Passkeys
 use passkey::{
-    authenticator::{Authenticator, UserCheck, UserValidationMethod},
+    authenticator::{Authenticator, UiHint, UserCheck, UserValidationMethod},
     client::{Client, WebauthnError},
     types::{Bytes, Passkey, crypto::sha256, ctap2::*, rand::random_vec, webauthn::*},
 };
@@ -17,7 +17,7 @@ impl UserValidationMethod for MyUserValidationMethod {
 
     async fn check_user<'a>(
         &self,
-        _credential: Option<&'a Passkey>,
+        _hint: UiHint<'a, Self::PasskeyItem>,
         presence: bool,
         verification: bool,
     ) -> Result<UserCheck, Ctap2Error> {

--- a/passkey/src/lib.rs
+++ b/passkey/src/lib.rs
@@ -64,7 +64,7 @@
 //! In this example, we are going to manually create a `CredentialCreationOptions` struct with hypothetical values named `*_from_rp` to indicate that these are values that would usually be supplied by the Relying Party. For simplicity, most of the `CredentialCreationOptions` are being set to `None` here.
 //! ```
 //! use passkey::{
-//!     authenticator::{Authenticator, UserValidationMethod, UserCheck},
+//!     authenticator::{Authenticator, UiHint, UserValidationMethod, UserCheck},
 //!     client::{Client, DefaultClientData, WebauthnError},
 //!     types::{ctap2::*, rand::random_vec, crypto::sha256, webauthn::*, Bytes, Passkey},
 //! };
@@ -80,7 +80,7 @@
 //! #
 //! #     async fn check_user<'a>(
 //! #         &self,
-//! #         _credential: Option<&'a Self::PasskeyItem>,
+//! #         _hint: UiHint<'a, Self::PasskeyItem>,
 //! #         presence: bool,
 //! #         verification: bool,
 //! #     ) -> Result<UserCheck, Ctap2Error> {
@@ -178,7 +178,7 @@
 //!
 //! ```
 //! # use passkey::{
-//! #     authenticator::{Authenticator, UserValidationMethod, UserCheck},
+//! #     authenticator::{Authenticator, UiHint, UserValidationMethod, UserCheck},
 //! #     client::{Client, WebauthnError},
 //! #     types::{ctap2::*, rand::random_vec, crypto::sha256, webauthn::*, Bytes, Passkey},
 //! # };
@@ -194,7 +194,7 @@
 //! #
 //! #     async fn check_user<'a>(
 //! #         &self,
-//! #         _credential: Option<&'a Self::PasskeyItem>,
+//! #         _hint: UiHint<'a, Self::PasskeyItem>,
 //! #         presence: bool,
 //! #         verification: bool,
 //! #     ) -> Result<UserCheck, Ctap2Error> {


### PR DESCRIPTION
Using `check_user()` as the central place to prompt and notify the user during the credential ceremonies, this replaces the `Option<PasskeyItem>` passed to `check_user()` with a more specific type, `UiHint`, that gives more context for the user interface to know what to inform the user about what has happened/needs to happen next.

I think `UiHint` is a decent name for this, but it collides with other meanings of "hints" in WebAuthn/CTAP2, so I'm open to other names too.