### PR TITLE
Allow using coset 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/1Password/passkey-rs"
 rust-version = "1.85.1"
 
+[workspace.dependencies]
+coset = ">=0.3.8, <=0.4"
+
 [workspace.lints.rust]
 missing_docs = "warn"
 unused-qualifications = "deny"

--- a/passkey-authenticator/Cargo.toml
+++ b/passkey-authenticator/Cargo.toml
@@ -22,7 +22,7 @@ tokio = ["dep:tokio"]
 
 [dependencies]
 async-trait = "0.1"
-coset = "0.3"
+coset = { workspace = true }
 log = "0.4"
 mockall = { version = "0.11", optional = true }
 p256 = { version = "0.13", features = ["arithmetic", "jwk", "pem"] }

--- a/passkey-client/Cargo.toml
+++ b/passkey-client/Cargo.toml
@@ -24,7 +24,7 @@ tokio = ["dep:tokio"]
 
 [dependencies]
 ciborium = "0.2"
-coset = "0.3"
+coset = { workspace = true }
 idna = "1"
 itertools = "0.14"
 mockall = { version = "0.11", optional = true }
@@ -40,7 +40,7 @@ typeshare = "1"
 url = "2"
 
 [dev-dependencies]
-coset = "0.3"
+coset = { workspace = true }
 mockall = { version = "0.11" }
 passkey-authenticator = { path = "../passkey-authenticator", version = "0.5", features = [
   "testable",

--- a/passkey-types/Cargo.toml
+++ b/passkey-types/Cargo.toml
@@ -35,7 +35,7 @@ typeshare = "1"
 url = { version = "2", features = ["serde"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 # TODO: investigate rolling our own IANA listings and COSE keys
-coset = "0.3"
+coset = { workspace = true }
 p256 = { version = "0.13", features = [
   "arithmetic",
   "jwk",

--- a/passkey/Cargo.toml
+++ b/passkey/Cargo.toml
@@ -30,7 +30,7 @@ passkey-types = { path = "../passkey-types", version = "0.5" }
 
 [dev-dependencies]
 async-trait = "0.1"
-coset = "0.3"
+coset = { workspace = true }
 passkey-authenticator = { path = "../passkey-authenticator", version = "0.5", features = [
   "testable",
   "tokio",


### PR DESCRIPTION
coset 0.4's [breaking changes](https://github.com/google/coset/blob/v0.4.0/CHANGELOG.md#040---2025-09-22) do not affect this crate, so we can allow both 0.3 and 0.4.

Alternatively, we could update the minimum version to 0.4 to make the width of dependencies smaller.

This also moves coset to be defined in the workspace, ensuring that all the crates have the same version.
