### PR TITLE
ci: Make step permissions and names explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,80 +8,125 @@ on:
 
 name: CI
 
+permissions: {}
+
 jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     strategy:
       matrix:
         rust:
           - 1.85.1
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           components: clippy
-      - run: rustup run ${{ matrix.rust }} cargo clippy --all --all-targets --all-features -- -D warnings
+
+      - name: Run Clippy
+        run: rustup run ${{ matrix.rust }} cargo clippy --all --all-targets --all-features -- -D warnings
 
   fmt:
     name: Rustfmt
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     strategy:
       matrix:
         rust:
           - 1.85.1
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           components: rustfmt
-      - run: rustup run ${{ matrix.rust }} cargo fmt --all -- --check
+
+      - name: Run Rustfmt
+        run: rustup run ${{ matrix.rust }} cargo fmt --all -- --check
 
   semver-checks:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
-      - name: Checkout
+      - name: Check out repo
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
 
   docs:
     name: Documentation
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     strategy:
       matrix:
         rust:
           - 1.85.1
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
-      - run: RUSTDOCFLAGS="-D warnings " rustup run ${{ matrix.rust }} cargo doc --workspace --no-deps --all-features
+
+      - name: Run rustdoc
+        run: RUSTDOCFLAGS="-D warnings " rustup run ${{ matrix.rust }} cargo doc --workspace --no-deps --all-features
 
   test:
     name: Test
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     strategy:
       matrix:
         rust:
           - 1.85.1
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
-      - run: rustup run ${{ matrix.rust }} cargo test
+
+      - name: Run tests
+        run: rustup run ${{ matrix.rust }} cargo test
 
   typeshare:
     name: Typeshare
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     strategy:
       matrix:
         rust:
@@ -98,9 +143,16 @@ jobs:
           - fs: swift
             lang: swift
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/install@v0.1
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install typeshare CLI
+        uses: actions-rs/install@v0.1
         with:
           crate: typeshare-cli
           version: "1.13.4"
-      - run: typeshare --lang=${{ matrix.lang }} . -o test.${{ matrix.fs }}
+
+      - name: Run typeshare CLI
+        run: typeshare --lang=${{ matrix.lang }} . -o test.${{ matrix.fs }}


### PR DESCRIPTION
This is in line with Bitwarden's policies, but I think it's generally applicable and helps us to upstream other PRs.