### PR TITLE
Fix RP ID domain validation to require dot boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### passkey-client
+
+- Fix RP ID validation to require dot boundary ([#92](https://github.com/1Password/passkey-rs/pull/92))
+
 ## Passkey v0.5.0
 
 - Migrate project to Rust 2024 edition

--- a/passkey-client/src/rp_id_verifier.rs
+++ b/passkey-client/src/rp_id_verifier.rs
@@ -78,7 +78,7 @@ where
         let mut effective_domain = origin.domain().ok_or(WebauthnError::OriginMissingDomain)?;
 
         if let Some(rp_id) = rp_id {
-            if !effective_domain.ends_with(rp_id) {
+            if !is_registrable_suffix_of_or_equal_to(effective_domain, rp_id) {
                 effective_domain = self
                     .validate_related_origins(rp_id, effective_domain)
                     .await?;
@@ -152,7 +152,7 @@ where
 
         if let Some(rp_id) = rp_id {
             // subset from assert_web_rp_id
-            if !effective_rp_id.ends_with(rp_id) {
+            if !is_registrable_suffix_of_or_equal_to(effective_rp_id, rp_id) {
                 return Err(WebauthnError::OriginRpMissmatch);
             }
             effective_rp_id = rp_id;
@@ -180,13 +180,16 @@ where
         rp_id: &'a str,
         effective_domain: &'a str,
     ) -> Result<&'a str, WebauthnError> {
-        let Some(ref fetcher) = self.fetcher else {
-            return Err(WebauthnError::OriginRpMissmatch);
-        };
-
+        // First check whether we even have a valid RP ID before attempting
+        // to see if we have the means to fetch .well-known. This ordering is
+        // important for the error variants we expect to see.
         if let ControlFlow::Break(res) = self.assert_valid_rp_id(rp_id) {
             return res;
         }
+
+        let Some(ref fetcher) = self.fetcher else {
+            return Err(WebauthnError::OriginRpMissmatch);
+        };
 
         let well_known_url = Url::parse(&format!("https://{rp_id}/.well-known/webauthn"))
             .expect("Building well_known_url unexpectedly failed");
@@ -196,7 +199,7 @@ where
 
         if final_url
             .domain()
-            .filter(|domain| domain.ends_with(rp_id))
+            .filter(|domain| is_registrable_suffix_of_or_equal_to(domain, rp_id))
             .is_none()
         {
             return Err(WebauthnError::RedirectError);
@@ -249,6 +252,18 @@ where
 
         Ok(rp_id)
     }
+}
+
+/// Checks whether `host` is a registrable domain suffix of or is equal to `rp_id`,
+/// per <https://html.spec.whatwg.org/multipage/browsers.html#is-a-registrable-domain-suffix-of-or-is-equal-to>.
+///
+/// This requires that `host` either equals `rp_id` exactly, or ends with `".{rp_id}"`,
+/// preventing `evil-example.com` from matching `example.com`.
+fn is_registrable_suffix_of_or_equal_to(host: &str, rp_id: &str) -> bool {
+    host == rp_id
+        || host
+            .strip_suffix(rp_id)
+            .is_some_and(|prefix| prefix.ends_with('.'))
 }
 
 /// Returns a decoded [String] if the domain name is punycode otherwise

--- a/passkey-client/src/rp_id_verifier/tests.rs
+++ b/passkey-client/src/rp_id_verifier/tests.rs
@@ -1,7 +1,10 @@
+use std::borrow::Cow;
+
 use passkey_types::webauthn::WellKnown;
 use public_suffix::DEFAULT_PROVIDER;
 use url::Url;
 
+use super::is_registrable_suffix_of_or_equal_to;
 use crate::{Fetcher, Origin, RelatedOriginResponse, RpIdVerifier, WebauthnError};
 
 pub struct TestFetcher {
@@ -155,7 +158,7 @@ async fn microsoft_sanity_check() {
         .expect_err("kolide sub domain should not match");
     assert_eq!(should_error, WebauthnError::OriginRpMissmatch);
 
-    let ms_origin = Origin::Web(std::borrow::Cow::Owned(
+    let ms_origin = Origin::Web(Cow::Owned(
         Url::parse("https://login.microsoft.com").unwrap(),
     ));
     let ms_rpid = verifier
@@ -188,4 +191,55 @@ async fn assert_invalid_rp_id_doesnt_panic() {
         .await
         .expect_err("kolide sub domain should not match");
     assert_eq!(should_error, WebauthnError::InvalidRpId);
+}
+
+#[test]
+fn suffix_match_requires_dot_boundary() {
+    // Exact match
+    assert!(is_registrable_suffix_of_or_equal_to(
+        "example.com",
+        "example.com"
+    ));
+
+    // Valid subdomain match (dot boundary)
+    assert!(is_registrable_suffix_of_or_equal_to(
+        "sub.example.com",
+        "example.com"
+    ));
+    assert!(is_registrable_suffix_of_or_equal_to(
+        "a.b.example.com",
+        "example.com"
+    ));
+
+    // Attack: domain that ends with the rp_id string but without a dot boundary
+    assert!(!is_registrable_suffix_of_or_equal_to(
+        "evil-example.com",
+        "example.com"
+    ));
+    assert!(!is_registrable_suffix_of_or_equal_to(
+        "notexample.com",
+        "example.com"
+    ));
+    assert!(!is_registrable_suffix_of_or_equal_to(
+        "fakeexample.com",
+        "example.com"
+    ));
+}
+
+#[tokio::test]
+async fn assert_domain_rejects_non_dot_boundary_rp_id() {
+    let fetcher = TestFetcher::default();
+    let verifier = RpIdVerifier::new(DEFAULT_PROVIDER, Some(fetcher));
+
+    // evil-1password.com should NOT be accepted for rp_id "1password.com"
+    let evil_origin = Origin::Web(Cow::Owned(
+        Url::parse("https://evil-1password.com").unwrap(),
+    ));
+    let result = verifier
+        .assert_domain(&evil_origin, Some("1password.com"))
+        .await;
+    assert!(
+        result.is_err(),
+        "evil-1password.com must not pass validation for rp_id 1password.com"
+    );
 }


### PR DESCRIPTION
The `ends_with()` check allowed attacker-controlled origins like `evil-example.com` to pass validation for RP ID `example.com`. This violates the W3C "is a registrable domain suffix of or is equal to" algorithm which requires a dot-prefixed suffix match. Replaced all three occurrences with a proper check that requires either an exact match or a dot-separated suffix.