### PR TITLE
Validate credential ID length during new credential registration

### DIFF
--- a/passkey-client/src/lib.rs
+++ b/passkey-client/src/lib.rs
@@ -87,6 +87,8 @@ pub enum WebauthnError {
     TimeoutError,
 }
 
+const MAX_CREDENTIAL_ID_LENGTH: usize = 1023;
+
 // Library sets tokio import as optional, timeouts rely on it
 // Not sure if tokio should still be optional but guarding for now to avoid breaking changes
 // https://www.w3.org/TR/webauthn-3/#recommended-range-and-default-for-a-webauthn-ceremony-timeout
@@ -343,6 +345,13 @@ where
             .attested_credential_data
             .as_ref()
             .unwrap();
+
+        // Validate returned credential ID length to comply with new credential registration ceremony spec
+        // https://w3c.github.io/webauthn/#sctn-registering-a-new-credential
+        if credential_id.credential_id().len() > MAX_CREDENTIAL_ID_LENGTH {
+            return Err(WebauthnError::CredentialIdTooLong);
+        }
+
         let alg = match credential_id.key.alg.as_ref().unwrap() {
             Algorithm::PrivateUse(val) => *val,
             Algorithm::Assigned(alg) => alg.to_i64(),


### PR DESCRIPTION

## #64 Add credential ID validation to comply with webauthn client [registration ceremony standard ](https://w3c.github.io/webauthn/#sctn-registering-a-new-credential)

Credential IDs in the exclude / allow credential lists should already be known so validating their length seems unnecessary, the standard also seems to make this assumption since there is no other len validation step. The only check the library is missing is:

*25. Verify that the [credentialId](https://w3c.github.io/webauthn/#authdata-attestedcredentialdata-credentialid) is ≤ 1023 bytes. Credential IDs larger than this many bytes SHOULD cause the RP to fail this [registration ceremony](https://w3c.github.io/webauthn/#registration-ceremony).*  