### PR TITLE
Add PIN/UV auth functionality for USB HID authenticators on Linux

### DIFF
--- a/passkey-authenticator/src/linux.rs
+++ b/passkey-authenticator/src/linux.rs
@@ -21,8 +21,9 @@ use std::path::Path;
 use passkey_transports::hid::{Command, Message};
 use passkey_transports::hidraw::{DeviceInfo, HidDevice, HidrawError, enumerate_fido_devices};
 use passkey_types::ctap2::{
-    Ctap2Command, Ctap2Error, StatusCode, U2FError, get_assertion, get_info, make_credential,
+    client_pin, get_assertion, get_info, make_credential, Ctap2ClientPinSubcommand, Ctap2Code, Ctap2Command, Ctap2Error, StatusCode, U2FError
 };
+use passkey_types::Bytes;
 use tokio::sync::mpsc;
 
 use crate::Ctap2Api;
@@ -106,6 +107,23 @@ pub struct LinuxAuthenticatorInner {
 }
 
 impl LinuxAuthenticatorInner {
+    /// Issue `authenticatorSelection` against the device.
+    pub async fn authenticator_selection(
+        &mut self,
+    ) -> Result<(), StatusCode> {
+        let response = self.send_cbor_with_cancel(Ctap2Command::AuthenticatorSelection, &[])
+            .await;
+        if let Err(
+            TransactionError::Status(StatusCode::Ctap2(
+                Ctap2Code::Known(Ctap2Error::Ok)
+            ))
+        ) = response {
+            Ok(())
+        } else {
+            response.map(|_| ()).map_err(StatusCode::from)
+        }
+    }
+
     /// Issue `authenticatorMakeCredential` against the device.
     pub async fn make_credential(
         &mut self,
@@ -136,6 +154,148 @@ impl LinuxAuthenticatorInner {
             .map_err(StatusCode::from)?;
         ciborium::de::from_reader(response.get_payload())
             .map_err(|_| StatusCode::from(Ctap2Error::InvalidCbor))
+    }
+
+     /// Fetch public key from device using the given protocol.
+    pub async fn get_public_key(&mut self, protocol: u8) -> Result<coset::CoseKey, StatusCode>  {
+        let request = client_pin::Request {
+            pin_uv_auth_protocol: Some(protocol),
+            sub_command: Ctap2ClientPinSubcommand::GetKeyAgreement.into(),
+            key_agreement: None,
+            pin_uv_auth_param: None,
+            new_pin_enc: None,
+            pin_hash_enc: None,
+            permissions: None,
+            rp_id: None,
+        };
+        let mut body = Vec::new();
+        ciborium::ser::into_writer(&request, &mut body)
+            .map_err(|_| StatusCode::from(U2FError::Other))?;
+        let response = self.send_cbor_with_cancel(Ctap2Command::ClientPin, &body)
+            .await
+            .map_err(StatusCode::from)?;
+        let response: client_pin::Response = ciborium::de::from_reader(response.get_payload()).unwrap();
+        // TODO: remove this expect
+        Ok(response.key_agreement.expect("should have a key agreement"))
+    }
+
+    /// `getPinToken` subcommand of `clientPin`.
+    pub async fn get_pin_token(
+        &mut self,
+        protocol: u8,
+        key_agreement: coset::CoseKey,
+        pin_hash_enc: Bytes,
+    ) -> Result<Bytes, StatusCode> {
+        let request = client_pin::Request {
+            pin_uv_auth_protocol: Some(protocol),
+            sub_command: Ctap2ClientPinSubcommand::GetPinToken.into(),
+            key_agreement: Some(key_agreement),
+            pin_uv_auth_param: None,
+            new_pin_enc: None,
+            pin_hash_enc: Some(pin_hash_enc),
+            permissions: None,
+            rp_id: None,
+        };
+        let mut body = Vec::new();
+        ciborium::ser::into_writer(&request, &mut body)
+            .map_err(|_| StatusCode::from(U2FError::Other))?;
+        let response = self.send_cbor_with_cancel(Ctap2Command::ClientPin, &body)
+            .await
+            .map_err(StatusCode::from)?;
+        let response: client_pin::Response = ciborium::de::from_reader(response.get_payload()).unwrap_or_default();
+        // TODO: remove this expect
+        Ok(response.pin_uv_auth_token.expect("should have a pinUvAuthToken"))
+    }
+
+    /// `getPinUvAuthTokenUsingUvWithPermissions` subcommand of `clientPin`.
+    pub async fn get_pin_uv_auth_token_using_uv(
+        &mut self,
+        protocol: u8,
+        key_agreement: coset::CoseKey,
+        permissions: client_pin::Permissions,
+        // rp_id is required for both make_credential and get_assertion, but we leave
+        // it as an Option here in case we need to add support for other permissions and don't
+        // want to break backwards compatibility.
+        rp_id: Option<String>,
+    ) -> Result<Bytes, StatusCode> {
+        let request = client_pin::Request {
+            pin_uv_auth_protocol: Some(protocol),
+            sub_command: Ctap2ClientPinSubcommand::GetPinUvAuthTokenUsingUvWithPermissions.into(),
+            key_agreement: Some(key_agreement),
+            pin_uv_auth_param: None,
+            new_pin_enc: None,
+            pin_hash_enc: None,
+            permissions: Some(permissions),
+            rp_id,
+        };
+        let mut body = Vec::new();
+        ciborium::ser::into_writer(&request, &mut body)
+            .map_err(|_| StatusCode::from(U2FError::Other))?;
+        let response = self.send_cbor_with_cancel(Ctap2Command::ClientPin, &body)
+            .await
+            .map_err(StatusCode::from)?;
+        let response: client_pin::Response = ciborium::de::from_reader(response.get_payload()).unwrap_or_default();
+        // TODO: remove this expect
+        Ok(response.pin_uv_auth_token.expect("should have a pinUvAuthToken"))
+    }
+
+    /// `getPinUvAuthTokenUsingPinWithPermissions` subcommand of `clientPin`.
+    pub async fn get_pin_uv_auth_token_using_pin(
+        &mut self,
+        protocol: u8,
+        key_agreement: coset::CoseKey,
+        pin_hash_enc: Bytes,
+        permissions: client_pin::Permissions,
+        // rp_id is required for both make_credential and get_assertion, but we leave
+        // it as an Option here in case we need to add support for other permissions and don't
+        // want to break backwards compatibility.
+        rp_id: Option<String>,
+    ) -> Result<Bytes, StatusCode> {
+        let request = client_pin::Request {
+            pin_uv_auth_protocol: Some(protocol),
+            sub_command: Ctap2ClientPinSubcommand::GetPinUvAuthTokenUsingPinWithPermissions.into(),
+            key_agreement: Some(key_agreement),
+            pin_uv_auth_param: None,
+            new_pin_enc: None,
+            pin_hash_enc: Some(pin_hash_enc),
+            permissions: Some(permissions),
+            rp_id,
+        };
+        let mut body = Vec::new();
+        ciborium::ser::into_writer(&request, &mut body)
+            .map_err(|_| StatusCode::from(U2FError::Other))?;
+        let response = self.send_cbor_with_cancel(Ctap2Command::ClientPin, &body)
+            .await
+            .map_err(StatusCode::from)?;
+        let response: client_pin::Response = ciborium::de::from_reader(response.get_payload()).unwrap_or_default();
+        // TODO: remove this expect
+        Ok(response.pin_uv_auth_token.expect("should have a pinUvAuthToken"))
+    }
+
+    /// `getPinRetries` subcommand of `clientPin`.
+    pub async fn get_pin_retries(
+        &mut self,
+        protocol: u8,
+    ) -> Result<u32, StatusCode> {
+        let request = client_pin::Request {
+            pin_uv_auth_protocol: Some(protocol),
+            sub_command: Ctap2ClientPinSubcommand::GetPinRetries.into(),
+            key_agreement: None,
+            pin_uv_auth_param: None,
+            new_pin_enc: None,
+            pin_hash_enc: None,
+            permissions: None,
+            rp_id: None,
+        };
+        let mut body = Vec::new();
+        ciborium::ser::into_writer(&request, &mut body)
+            .map_err(|_| StatusCode::from(U2FError::Other))?;
+        let response = self.send_cbor_with_cancel(Ctap2Command::ClientPin, &body)
+            .await
+            .map_err(StatusCode::from)?;
+        let response: client_pin::Response = ciborium::de::from_reader(response.get_payload()).unwrap_or_default();
+        // TODO: remove this expect
+        Ok(response.pin_retries.expect("Should have pin retries"))
     }
 
     /// Send a CTAPHID_CBOR request and await its response, forwarding any
@@ -182,6 +342,27 @@ impl LinuxAuthenticator {
         enumerate_fido_devices()
     }
 
+    /// Whether builtin UV is configured for this device.
+    pub fn uv_configured(&self) -> bool {
+        self.info().options.and_then(|o| o.uv).unwrap_or(false)
+    }
+
+    /// Whether a PIN is configured for this device.
+    pub fn pin_configured(&self) -> bool {
+        self.info().options.and_then(|o| o.client_pin).unwrap_or(false)
+    }
+
+    /// Whether this device supports storing resident keys.
+    pub fn rk_supported(&self) -> bool {
+        self.info().options.is_some_and(|o| o.rk)
+    }
+
+    /// Whether the authenticator supports authenticatorClientPIN's
+    /// getPinUvAuthTokenUsingUvWithPermissions subcommand.
+    pub fn pin_uv_auth_token_supported(&self) -> bool {
+        self.info().options.map(|o| o.pin_uv_auth_token == Some(true)).unwrap_or(false)
+    }
+
     /// Open a specific `/dev/hidrawN` path, run `CTAPHID_INIT` to obtain a private
     /// channel, and prime the cached `authenticatorGetInfo` response.
     pub async fn open(path: &Path) -> Result<Self, OpenError> {
@@ -221,6 +402,8 @@ impl LinuxAuthenticator {
     pub fn info(&self) -> get_info::Response {
         ciborium::de::from_reader(self.inner.get_info_cbor.get_payload()).unwrap_or_default()
     }
+
+    // TODO: remove these functions?
 
     /// Issue `authenticatorMakeCredential` against the device.
     pub async fn make_credential(

--- a/passkey-authenticator/src/linux.rs
+++ b/passkey-authenticator/src/linux.rs
@@ -210,7 +210,7 @@ impl LinuxAuthenticatorInner {
     pub async fn get_public_key(&mut self, protocol: u8) -> Result<coset::CoseKey, StatusCode> {
         let request = client_pin::Request {
             pin_uv_auth_protocol: Some(protocol),
-            sub_command: Ctap2ClientPinSubcommand::GetKeyAgreement.into(),
+            sub_command: Ctap2ClientPinSubcommand::GetKeyAgreement,
             key_agreement: None,
             pin_uv_auth_param: None,
             new_pin_enc: None,
@@ -240,7 +240,7 @@ impl LinuxAuthenticatorInner {
     ) -> Result<Bytes, StatusCode> {
         let request = client_pin::Request {
             pin_uv_auth_protocol: Some(protocol),
-            sub_command: Ctap2ClientPinSubcommand::GetPinToken.into(),
+            sub_command: Ctap2ClientPinSubcommand::GetPinToken,
             key_agreement: Some(key_agreement),
             pin_uv_auth_param: None,
             new_pin_enc: None,
@@ -276,7 +276,7 @@ impl LinuxAuthenticatorInner {
     ) -> Result<Bytes, StatusCode> {
         let request = client_pin::Request {
             pin_uv_auth_protocol: Some(protocol),
-            sub_command: Ctap2ClientPinSubcommand::GetPinUvAuthTokenUsingUvWithPermissions.into(),
+            sub_command: Ctap2ClientPinSubcommand::GetPinUvAuthTokenUsingUvWithPermissions,
             key_agreement: Some(key_agreement),
             pin_uv_auth_param: None,
             new_pin_enc: None,
@@ -313,7 +313,7 @@ impl LinuxAuthenticatorInner {
     ) -> Result<Bytes, StatusCode> {
         let request = client_pin::Request {
             pin_uv_auth_protocol: Some(protocol),
-            sub_command: Ctap2ClientPinSubcommand::GetPinUvAuthTokenUsingPinWithPermissions.into(),
+            sub_command: Ctap2ClientPinSubcommand::GetPinUvAuthTokenUsingPinWithPermissions,
             key_agreement: Some(key_agreement),
             pin_uv_auth_param: None,
             new_pin_enc: None,
@@ -340,7 +340,7 @@ impl LinuxAuthenticatorInner {
     pub async fn get_pin_retries(&mut self, protocol: u8) -> Result<u32, StatusCode> {
         let request = client_pin::Request {
             pin_uv_auth_protocol: Some(protocol),
-            sub_command: Ctap2ClientPinSubcommand::GetPinRetries.into(),
+            sub_command: Ctap2ClientPinSubcommand::GetPinRetries,
             key_agreement: None,
             pin_uv_auth_param: None,
             new_pin_enc: None,
@@ -359,6 +359,31 @@ impl LinuxAuthenticatorInner {
             ciborium::de::from_reader(response.get_payload()).unwrap_or_default();
         // TODO: remove this expect
         Ok(response.pin_retries.expect("Should have pin retries"))
+    }
+
+    /// `getUvRetries` subcommand of `clientPin`.
+    pub async fn get_uv_retries(&mut self, protocol: u8) -> Result<u32, StatusCode> {
+        let request = client_pin::Request {
+            pin_uv_auth_protocol: Some(protocol),
+            sub_command: Ctap2ClientPinSubcommand::GetUvRetries,
+            key_agreement: None,
+            pin_uv_auth_param: None,
+            new_pin_enc: None,
+            pin_hash_enc: None,
+            permissions: None,
+            rp_id: None,
+        };
+        let mut body = Vec::new();
+        ciborium::ser::into_writer(&request, &mut body)
+            .map_err(|_| StatusCode::from(U2FError::Other))?;
+        let response = self
+            .send_cbor_with_cancel(Ctap2Command::ClientPin, &body)
+            .await
+            .map_err(StatusCode::from)?;
+        let response: client_pin::Response =
+            ciborium::de::from_reader(response.get_payload()).unwrap_or_default();
+        // TODO: remove this expect
+        Ok(response.pin_retries.expect("Should have UV retries"))
     }
 
     /// Send a CTAPHID_CBOR request and await its response, forwarding any
@@ -470,24 +495,6 @@ impl LinuxAuthenticator {
     /// Read and decode the cached `authenticatorGetInfo` response.
     pub fn info(&self) -> get_info::Response {
         ciborium::de::from_reader(self.inner.get_info_cbor.get_payload()).unwrap_or_default()
-    }
-
-    // TODO: remove these functions?
-
-    /// Issue `authenticatorMakeCredential` against the device.
-    pub async fn make_credential(
-        &mut self,
-        request: make_credential::Request,
-    ) -> Result<make_credential::Response, StatusCode> {
-        self.inner.make_credential(request).await
-    }
-
-    /// Issue `authenticatorGetAssertion` against the device.
-    pub async fn get_assertion(
-        &mut self,
-        request: get_assertion::Request,
-    ) -> Result<get_assertion::Response, StatusCode> {
-        self.inner.get_assertion(request).await
     }
 }
 

--- a/passkey-authenticator/src/linux.rs
+++ b/passkey-authenticator/src/linux.rs
@@ -23,7 +23,7 @@ use passkey_transports::hidraw::{DeviceInfo, HidDevice, HidrawError, enumerate_f
 use passkey_types::ctap2::{
     client_pin, get_assertion, get_info, make_credential, Ctap2ClientPinSubcommand, Ctap2Code, Ctap2Command, Ctap2Error, StatusCode, U2FError
 };
-use passkey_types::Bytes;
+use passkey_types::{webauthn, Bytes};
 use tokio::sync::mpsc;
 
 use crate::Ctap2Api;
@@ -107,20 +107,69 @@ pub struct LinuxAuthenticatorInner {
 }
 
 impl LinuxAuthenticatorInner {
-    /// Issue `authenticatorSelection` against the device.
-    pub async fn authenticator_selection(
-        &mut self,
-    ) -> Result<(), StatusCode> {
-        let response = self.send_cbor_with_cancel(Ctap2Command::AuthenticatorSelection, &[])
+    /// Determine whether the device supports CTAP 2.1 or greater. If it does, issue an
+    /// `authenticatorSelection` command. Otherwise, issue `authenticatorMakeCredential` with a
+    /// zero-length `pinUvAuthToken`. Returns when the user provides UP on the device.
+    pub async fn authenticator_selection(&mut self) -> Result<(), StatusCode> {
+        let info: get_info::Response = ciborium::de::from_reader(self.get_info_cbor.get_payload()).unwrap_or_default();
+        let authenticator_selection_unsupported = info
+            .versions
+            .iter()
+            .all(|e| *e == get_info::Version::U2F_V2 || *e == get_info::Version::FIDO_2_0);
+        if !authenticator_selection_unsupported {
+            let response = self.send_cbor_with_cancel(
+                Ctap2Command::AuthenticatorSelection,
+                &[],
+            )
             .await;
-        if let Err(
-            TransactionError::Status(StatusCode::Ctap2(
-                Ctap2Code::Known(Ctap2Error::Ok)
-            ))
-        ) = response {
-            Ok(())
+            if matches!(
+                response,
+                Err(TransactionError::Status(StatusCode::Ctap2(
+                    Ctap2Code::Known(Ctap2Error::Ok)
+                )))
+            ) {
+                Ok(())
+            } else {
+                response.map(|_| ()).map_err(StatusCode::from)
+            }
         } else {
-            response.map(|_| ()).map_err(StatusCode::from)
+            let dummy_request = make_credential::Request {
+                client_data_hash: Bytes::from(&[][..]),
+                rp: make_credential::PublicKeyCredentialRpEntity {
+                    id: String::new(),
+                    name: None,
+                },
+                user: webauthn::PublicKeyCredentialUserEntity {
+                    id: Bytes::from(&[][..]),
+                    display_name: String::new(),
+                    name: String::new(),
+                },
+                pub_key_cred_params: webauthn::PublicKeyCredentialParameters::default_algorithms(),
+                exclude_list: None,
+                extensions: None,
+                options: make_credential::Options {
+                    rk: false,
+                    up: false,
+                    uv: false,
+                },
+                pin_auth: Some(Bytes::from(&[][..])),
+                pin_protocol: Some(1),
+            };
+            let mut body = Vec::new();
+            ciborium::ser::into_writer(&dummy_request, &mut body)
+                .map_err(|_| StatusCode::from(U2FError::Other))?;
+            let response =
+                self.send_cbor_with_cancel(Ctap2Command::MakeCredential, &body).await;
+            if matches!(
+                response,
+                Err(TransactionError::Status(StatusCode::Ctap2(
+                    Ctap2Code::Known(Ctap2Error::PinNotSet | Ctap2Error::PinInvalid)
+                )))
+            ) {
+                Ok(())
+            } else {
+                response.map(|_| ()).map_err(StatusCode::from)
+            }
         }
     }
 

--- a/passkey-authenticator/src/linux.rs
+++ b/passkey-authenticator/src/linux.rs
@@ -21,9 +21,10 @@ use std::path::Path;
 use passkey_transports::hid::{Command, Message};
 use passkey_transports::hidraw::{DeviceInfo, HidDevice, HidrawError, enumerate_fido_devices};
 use passkey_types::ctap2::{
-    client_pin, get_assertion, get_info, make_credential, Ctap2ClientPinSubcommand, Ctap2Code, Ctap2Command, Ctap2Error, StatusCode, U2FError
+    Ctap2ClientPinSubcommand, Ctap2Code, Ctap2Command, Ctap2Error, StatusCode, U2FError,
+    client_pin, get_assertion, get_info, make_credential,
 };
-use passkey_types::{webauthn, Bytes};
+use passkey_types::{Bytes, webauthn};
 use tokio::sync::mpsc;
 
 use crate::Ctap2Api;
@@ -111,17 +112,16 @@ impl LinuxAuthenticatorInner {
     /// `authenticatorSelection` command. Otherwise, issue `authenticatorMakeCredential` with a
     /// zero-length `pinUvAuthToken`. Returns when the user provides UP on the device.
     pub async fn authenticator_selection(&mut self) -> Result<(), StatusCode> {
-        let info: get_info::Response = ciborium::de::from_reader(self.get_info_cbor.get_payload()).unwrap_or_default();
+        let info: get_info::Response =
+            ciborium::de::from_reader(self.get_info_cbor.get_payload()).unwrap_or_default();
         let authenticator_selection_unsupported = info
             .versions
             .iter()
             .all(|e| *e == get_info::Version::U2F_V2 || *e == get_info::Version::FIDO_2_0);
         if !authenticator_selection_unsupported {
-            let response = self.send_cbor_with_cancel(
-                Ctap2Command::AuthenticatorSelection,
-                &[],
-            )
-            .await;
+            let response = self
+                .send_cbor_with_cancel(Ctap2Command::AuthenticatorSelection, &[])
+                .await;
             if matches!(
                 response,
                 Err(TransactionError::Status(StatusCode::Ctap2(
@@ -158,8 +158,9 @@ impl LinuxAuthenticatorInner {
             let mut body = Vec::new();
             ciborium::ser::into_writer(&dummy_request, &mut body)
                 .map_err(|_| StatusCode::from(U2FError::Other))?;
-            let response =
-                self.send_cbor_with_cancel(Ctap2Command::MakeCredential, &body).await;
+            let response = self
+                .send_cbor_with_cancel(Ctap2Command::MakeCredential, &body)
+                .await;
             if matches!(
                 response,
                 Err(TransactionError::Status(StatusCode::Ctap2(
@@ -205,8 +206,8 @@ impl LinuxAuthenticatorInner {
             .map_err(|_| StatusCode::from(Ctap2Error::InvalidCbor))
     }
 
-     /// Fetch public key from device using the given protocol.
-    pub async fn get_public_key(&mut self, protocol: u8) -> Result<coset::CoseKey, StatusCode>  {
+    /// Fetch public key from device using the given protocol.
+    pub async fn get_public_key(&mut self, protocol: u8) -> Result<coset::CoseKey, StatusCode> {
         let request = client_pin::Request {
             pin_uv_auth_protocol: Some(protocol),
             sub_command: Ctap2ClientPinSubcommand::GetKeyAgreement.into(),
@@ -220,10 +221,12 @@ impl LinuxAuthenticatorInner {
         let mut body = Vec::new();
         ciborium::ser::into_writer(&request, &mut body)
             .map_err(|_| StatusCode::from(U2FError::Other))?;
-        let response = self.send_cbor_with_cancel(Ctap2Command::ClientPin, &body)
+        let response = self
+            .send_cbor_with_cancel(Ctap2Command::ClientPin, &body)
             .await
             .map_err(StatusCode::from)?;
-        let response: client_pin::Response = ciborium::de::from_reader(response.get_payload()).unwrap();
+        let response: client_pin::Response =
+            ciborium::de::from_reader(response.get_payload()).unwrap();
         // TODO: remove this expect
         Ok(response.key_agreement.expect("should have a key agreement"))
     }
@@ -248,12 +251,16 @@ impl LinuxAuthenticatorInner {
         let mut body = Vec::new();
         ciborium::ser::into_writer(&request, &mut body)
             .map_err(|_| StatusCode::from(U2FError::Other))?;
-        let response = self.send_cbor_with_cancel(Ctap2Command::ClientPin, &body)
+        let response = self
+            .send_cbor_with_cancel(Ctap2Command::ClientPin, &body)
             .await
             .map_err(StatusCode::from)?;
-        let response: client_pin::Response = ciborium::de::from_reader(response.get_payload()).unwrap_or_default();
+        let response: client_pin::Response =
+            ciborium::de::from_reader(response.get_payload()).unwrap_or_default();
         // TODO: remove this expect
-        Ok(response.pin_uv_auth_token.expect("should have a pinUvAuthToken"))
+        Ok(response
+            .pin_uv_auth_token
+            .expect("should have a pinUvAuthToken"))
     }
 
     /// `getPinUvAuthTokenUsingUvWithPermissions` subcommand of `clientPin`.
@@ -280,12 +287,16 @@ impl LinuxAuthenticatorInner {
         let mut body = Vec::new();
         ciborium::ser::into_writer(&request, &mut body)
             .map_err(|_| StatusCode::from(U2FError::Other))?;
-        let response = self.send_cbor_with_cancel(Ctap2Command::ClientPin, &body)
+        let response = self
+            .send_cbor_with_cancel(Ctap2Command::ClientPin, &body)
             .await
             .map_err(StatusCode::from)?;
-        let response: client_pin::Response = ciborium::de::from_reader(response.get_payload()).unwrap_or_default();
+        let response: client_pin::Response =
+            ciborium::de::from_reader(response.get_payload()).unwrap_or_default();
         // TODO: remove this expect
-        Ok(response.pin_uv_auth_token.expect("should have a pinUvAuthToken"))
+        Ok(response
+            .pin_uv_auth_token
+            .expect("should have a pinUvAuthToken"))
     }
 
     /// `getPinUvAuthTokenUsingPinWithPermissions` subcommand of `clientPin`.
@@ -313,19 +324,20 @@ impl LinuxAuthenticatorInner {
         let mut body = Vec::new();
         ciborium::ser::into_writer(&request, &mut body)
             .map_err(|_| StatusCode::from(U2FError::Other))?;
-        let response = self.send_cbor_with_cancel(Ctap2Command::ClientPin, &body)
+        let response = self
+            .send_cbor_with_cancel(Ctap2Command::ClientPin, &body)
             .await
             .map_err(StatusCode::from)?;
-        let response: client_pin::Response = ciborium::de::from_reader(response.get_payload()).unwrap_or_default();
+        let response: client_pin::Response =
+            ciborium::de::from_reader(response.get_payload()).unwrap_or_default();
         // TODO: remove this expect
-        Ok(response.pin_uv_auth_token.expect("should have a pinUvAuthToken"))
+        Ok(response
+            .pin_uv_auth_token
+            .expect("should have a pinUvAuthToken"))
     }
 
     /// `getPinRetries` subcommand of `clientPin`.
-    pub async fn get_pin_retries(
-        &mut self,
-        protocol: u8,
-    ) -> Result<u32, StatusCode> {
+    pub async fn get_pin_retries(&mut self, protocol: u8) -> Result<u32, StatusCode> {
         let request = client_pin::Request {
             pin_uv_auth_protocol: Some(protocol),
             sub_command: Ctap2ClientPinSubcommand::GetPinRetries.into(),
@@ -339,10 +351,12 @@ impl LinuxAuthenticatorInner {
         let mut body = Vec::new();
         ciborium::ser::into_writer(&request, &mut body)
             .map_err(|_| StatusCode::from(U2FError::Other))?;
-        let response = self.send_cbor_with_cancel(Ctap2Command::ClientPin, &body)
+        let response = self
+            .send_cbor_with_cancel(Ctap2Command::ClientPin, &body)
             .await
             .map_err(StatusCode::from)?;
-        let response: client_pin::Response = ciborium::de::from_reader(response.get_payload()).unwrap_or_default();
+        let response: client_pin::Response =
+            ciborium::de::from_reader(response.get_payload()).unwrap_or_default();
         // TODO: remove this expect
         Ok(response.pin_retries.expect("Should have pin retries"))
     }
@@ -398,7 +412,10 @@ impl LinuxAuthenticator {
 
     /// Whether a PIN is configured for this device.
     pub fn pin_configured(&self) -> bool {
-        self.info().options.and_then(|o| o.client_pin).unwrap_or(false)
+        self.info()
+            .options
+            .and_then(|o| o.client_pin)
+            .unwrap_or(false)
     }
 
     /// Whether this device supports storing resident keys.
@@ -409,7 +426,10 @@ impl LinuxAuthenticator {
     /// Whether the authenticator supports authenticatorClientPIN's
     /// getPinUvAuthTokenUsingUvWithPermissions subcommand.
     pub fn pin_uv_auth_token_supported(&self) -> bool {
-        self.info().options.map(|o| o.pin_uv_auth_token == Some(true)).unwrap_or(false)
+        self.info()
+            .options
+            .map(|o| o.pin_uv_auth_token == Some(true))
+            .unwrap_or(false)
     }
 
     /// Open a specific `/dev/hidrawN` path, run `CTAPHID_INIT` to obtain a private

--- a/passkey-client/Cargo.toml
+++ b/passkey-client/Cargo.toml
@@ -20,11 +20,12 @@ android-asset-validation = ["dep:nom"]
 testable = ["dep:mockall"]
 tokio = ["dep:tokio"]
 typeshare = ["passkey-types/typeshare", "dep:typeshare"]
-linux = ["dep:tokio", "passkey-authenticator/linux", "tokio/rt"]
+linux = ["dep:async-trait", "dep:tokio", "dep:zeroize", "passkey-authenticator/linux", "tokio/rt"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = { version = "0.1", optional = true }
 ciborium = "0.2"
 coset = { workspace = true }
 idna = "1"
@@ -40,6 +41,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["sync", "time", "rt"], optional = true }
 typeshare = { version = "1", optional = true }
 url = "2"
+zeroize = { version = "1", features = ["zeroize_derive"], optional = true }
 
 [dev-dependencies]
 coset = { workspace = true }

--- a/passkey-client/src/linux.rs
+++ b/passkey-client/src/linux.rs
@@ -24,9 +24,9 @@ use std::future::Future;
 use coset::{Algorithm, iana::EnumI64};
 use passkey_authenticator::linux::{LinuxAuthenticator, OpenError};
 use passkey_authenticator::public_key_der_from_cose_key;
+use passkey_types::Bytes;
 use passkey_types::crypto::{aes_256_cbc, hmac_sha256, sha256};
 use passkey_types::ctap2::pin_uv_auth_protocol::PinUvAuthProtocolOne;
-use passkey_types::Bytes;
 use passkey_types::{
     ctap2, encoding,
     webauthn::{
@@ -55,7 +55,10 @@ pub trait PinPrompt: Send + Sync {
     ) -> Result<(), PinPromptError>;
 
     /// Prompt user to enter a PIN.
-    async fn request_pin(&self, attempts_remaining: u32) -> Result<zeroize::Zeroizing<String>, PinPromptError>;
+    async fn request_pin(
+        &self,
+        attempts_remaining: u32,
+    ) -> Result<zeroize::Zeroizing<String>, PinPromptError>;
 }
 
 /// Error resulting from a prompt.
@@ -94,17 +97,21 @@ struct TokenWithProtocol {
     protocol: u8,
 }
 
-fn get_pin_auth_and_protocol(token_with_protocol: Option<TokenWithProtocol>, client_data_hash: &[u8]) -> (Option<Bytes>, Option<u8>) {
-        token_with_protocol
-            .map(|e| (
+fn get_pin_auth_and_protocol(
+    token_with_protocol: Option<TokenWithProtocol>,
+    client_data_hash: &[u8],
+) -> (Option<Bytes>, Option<u8>) {
+    token_with_protocol
+        .map(|e| {
+            (
                 Some(Bytes::from(
                     &hmac_sha256(e.token.as_slice(), client_data_hash)[0..16],
                 )),
-                Some(e.protocol)
-            ))
-            .unwrap_or((None, None))
+                Some(e.protocol),
+            )
+        })
+        .unwrap_or((None, None))
 }
-
 
 impl LinuxClient<public_suffix::PublicSuffixList, ()> {
     /// Build a `LinuxClient` over the supplied authenticators using the default public-suffix list
@@ -183,9 +190,7 @@ where
         // Determine if any device has been configured to use built-in UV or a PIN.
         let any_device_requires_uv = devices
             .iter()
-            .any(|device| 
-                device.uv_configured() || device.pin_configured()
-            );
+            .any(|device| device.uv_configured() || device.pin_configured());
 
         // We need to prompt the user to provide UV if the request requires user verification OR if
         // any device requires UV. In order to do this, we first need them to provide UP to an authenticator
@@ -210,11 +215,14 @@ where
                 if let Some((_, winning_device)) = winner {
                     winning_device
                 } else {
-                    return Err(WebauthnError::AuthenticatorError(errors.pop().unwrap_or(
-                        ctap2::StatusCode::Ctap2(
-                                ctap2::Ctap2Code::Known(ctap2::Ctap2Error::UserPresenceRequired)
-                        )
-                    ).into()));
+                    return Err(WebauthnError::AuthenticatorError(
+                        errors
+                            .pop()
+                            .unwrap_or(ctap2::StatusCode::Ctap2(ctap2::Ctap2Code::Known(
+                                ctap2::Ctap2Error::UserPresenceRequired,
+                            )))
+                            .into(),
+                    ));
                 }
             };
 
@@ -239,7 +247,9 @@ where
                 None
             };
 
-            let token_with_protocol = self.get_auth_token_for_device(&mut selected_device, selected_operation, rp_id).await?;
+            let token_with_protocol = self
+                .get_auth_token_for_device(&mut selected_device, selected_operation, rp_id)
+                .await?;
 
             vec![(selected_device, token_with_protocol)]
         } else {
@@ -263,57 +273,89 @@ where
             Some(op) => {
                 // Obtain platform key-agreement key and shared secret.
                 let pin_uv_auth_protocol = 1;
-                let public_key = selected_device.inner.get_public_key(pin_uv_auth_protocol).await?;
-                let (platform_key_agreement_key, shared_secret) = self.pin_uv_auth_protocol_state.encapsulate(&public_key).map_err(ctap2::StatusCode::from)?;
-                let permissions = ctap2::client_pin::Permissions::MC | ctap2::client_pin::Permissions::GA;
+                let public_key = selected_device
+                    .inner
+                    .get_public_key(pin_uv_auth_protocol)
+                    .await?;
+                let (platform_key_agreement_key, shared_secret) = self
+                    .pin_uv_auth_protocol_state
+                    .encapsulate(&public_key)
+                    .map_err(ctap2::StatusCode::from)?;
+                let permissions =
+                    ctap2::client_pin::Permissions::MC | ctap2::client_pin::Permissions::GA;
                 let encrypted_token = match op {
                     GetPinUvAuthTokenOp::GetPinUvAuthTokenUsingPinWithPermissions => {
-                        let attempts_remaining = selected_device.inner.get_pin_retries(pin_uv_auth_protocol).await?;
-                        let pin = self.pin_prompt.request_pin(attempts_remaining).await.map_err(|_| WebauthnError::NotSupportedError)?;
-                        let encrypted_pin = aes_256_cbc(
-                            shared_secret,
-                            [0; 16],
-                            &sha256(pin.as_bytes())[0..16]
-                        ).into();
-                        selected_device.inner.get_pin_uv_auth_token_using_pin(
-                            pin_uv_auth_protocol,
-                            platform_key_agreement_key,
-                            encrypted_pin,
-                            permissions,
-                            Some(rp_id.to_owned()),
-                        ).await?
+                        let attempts_remaining = selected_device
+                            .inner
+                            .get_pin_retries(pin_uv_auth_protocol)
+                            .await?;
+                        let pin = self
+                            .pin_prompt
+                            .request_pin(attempts_remaining)
+                            .await
+                            .map_err(|_| WebauthnError::NotSupportedError)?;
+                        let encrypted_pin =
+                            aes_256_cbc(shared_secret, [0; 16], &sha256(pin.as_bytes())[0..16])
+                                .into();
+                        selected_device
+                            .inner
+                            .get_pin_uv_auth_token_using_pin(
+                                pin_uv_auth_protocol,
+                                platform_key_agreement_key,
+                                encrypted_pin,
+                                permissions,
+                                Some(rp_id.to_owned()),
+                            )
+                            .await?
                     }
                     GetPinUvAuthTokenOp::GetPinUvAuthTokenUsingUvWithPermissions => {
-                        selected_device.inner.get_pin_uv_auth_token_using_uv(
-                            pin_uv_auth_protocol,
-                            platform_key_agreement_key,
-                            permissions,
-                            Some(rp_id.to_owned()),
-                        ).await?
+                        selected_device
+                            .inner
+                            .get_pin_uv_auth_token_using_uv(
+                                pin_uv_auth_protocol,
+                                platform_key_agreement_key,
+                                permissions,
+                                Some(rp_id.to_owned()),
+                            )
+                            .await?
                     }
                     GetPinUvAuthTokenOp::GetPinToken => {
                         // TODO: use getUvRetries here
-                        let attempts_remaining = selected_device.inner.get_pin_retries(pin_uv_auth_protocol).await?;
-                        let pin = self.pin_prompt.request_pin(attempts_remaining).await.map_err(|_| WebauthnError::NotSupportedError)?;
-                        let encrypted_pin = aes_256_cbc(
-                            shared_secret,
-                            [0; 16],
-                            &sha256(pin.as_bytes())[0..16]
-                        ).into();
-                        selected_device.inner.get_pin_token(
-                            pin_uv_auth_protocol,
-                            platform_key_agreement_key,
-                            encrypted_pin,
-                        ).await?
+                        let attempts_remaining = selected_device
+                            .inner
+                            .get_pin_retries(pin_uv_auth_protocol)
+                            .await?;
+                        let pin = self
+                            .pin_prompt
+                            .request_pin(attempts_remaining)
+                            .await
+                            .map_err(|_| WebauthnError::NotSupportedError)?;
+                        let encrypted_pin =
+                            aes_256_cbc(shared_secret, [0; 16], &sha256(pin.as_bytes())[0..16])
+                                .into();
+                        selected_device
+                            .inner
+                            .get_pin_token(
+                                pin_uv_auth_protocol,
+                                platform_key_agreement_key,
+                                encrypted_pin,
+                            )
+                            .await?
                     }
                 };
 
                 // Decrypt the token using the shared secret before returning it.
-                let pin_uv_auth_token = Bytes::from(PinUvAuthProtocolOne::decrypt(&shared_secret, encrypted_token.as_slice()));
+                let pin_uv_auth_token = Bytes::from(PinUvAuthProtocolOne::decrypt(
+                    &shared_secret,
+                    encrypted_token.as_slice(),
+                ));
                 Some((pin_uv_auth_token, pin_uv_auth_protocol))
             }
         };
-        Ok(token_and_protocol.map(|e| TokenWithProtocol { token: e.0, protocol: e.1 }))
+        Ok(token_and_protocol.map(|e| TokenWithProtocol {
+            token: e.0,
+            protocol: e.1,
+        }))
     }
 
     /// Register a credential by racing every connected security key.
@@ -380,8 +422,8 @@ where
                 continue;
             }
 
-
-            let (pin_auth, pin_protocol) = get_pin_auth_and_protocol(token_with_protocol, &client_data_hash);
+            let (pin_auth, pin_protocol) =
+                get_pin_auth_and_protocol(token_with_protocol, &client_data_hash);
             let request = ctap2::make_credential::Request {
                 client_data_hash: client_data_hash.clone().into(),
                 rp: ctap2::make_credential::PublicKeyCredentialRpEntity {
@@ -497,7 +539,8 @@ where
                 preserved.push(device);
                 continue;
             }
-            let (pin_auth, pin_protocol) = get_pin_auth_and_protocol(token_with_protocol, &client_data_hash);
+            let (pin_auth, pin_protocol) =
+                get_pin_auth_and_protocol(token_with_protocol, &client_data_hash);
             let request = ctap2::get_assertion::Request {
                 rp_id: rp_id.clone(),
                 client_data_hash: client_data_hash.clone().into(),

--- a/passkey-client/src/linux.rs
+++ b/passkey-client/src/linux.rs
@@ -47,13 +47,6 @@ use crate::{
 /// Consumer-provided authenticator selection and PIN input prompts.
 #[async_trait::async_trait]
 pub trait PinPrompt: Send + Sync {
-    /// Prompt user to provide User Presence to a particular authenticator to select it for use.
-    /// Returning an error aborts the in-flight authenticator-selection race.
-    async fn prompt_authenticator_selection(
-        &self,
-        num_authenticators: usize,
-    ) -> Result<(), PinPromptError>;
-
     /// Prompt user to enter a PIN.
     async fn request_pin(
         &self,

--- a/passkey-client/src/linux.rs
+++ b/passkey-client/src/linux.rs
@@ -313,10 +313,9 @@ where
                             .await?
                     }
                     GetPinUvAuthTokenOp::GetPinToken => {
-                        // TODO: use getUvRetries here
                         let attempts_remaining = selected_device
                             .inner
-                            .get_pin_retries(pin_uv_auth_protocol)
+                            .get_uv_retries(pin_uv_auth_protocol)
                             .await?;
                         let pin = self
                             .pin_prompt

--- a/passkey-client/src/linux.rs
+++ b/passkey-client/src/linux.rs
@@ -24,6 +24,9 @@ use std::future::Future;
 use coset::{Algorithm, iana::EnumI64};
 use passkey_authenticator::linux::{LinuxAuthenticator, OpenError};
 use passkey_authenticator::public_key_der_from_cose_key;
+use passkey_types::crypto::{aes_256_cbc, hmac_sha256, sha256};
+use passkey_types::ctap2::pin_uv_auth_protocol::PinUvAuthProtocolOne;
+use passkey_types::Bytes;
 use passkey_types::{
     ctap2, encoding,
     webauthn::{
@@ -41,6 +44,36 @@ use crate::{
     map_rk,
 };
 
+/// Consumer-provided authenticator selection and PIN input prompts.
+#[async_trait::async_trait]
+pub trait PinPrompt: Send + Sync {
+    /// Prompt user to provide User Presence to a particular authenticator to select it for use.
+    /// Returning an error aborts the in-flight authenticator-selection race.
+    async fn prompt_authenticator_selection(
+        &self,
+        num_authenticators: usize,
+    ) -> Result<(), PinPromptError>;
+
+    /// Prompt user to enter a PIN.
+    async fn request_pin(&self, attempts_remaining: u32) -> Result<zeroize::Zeroizing<String>, PinPromptError>;
+}
+
+/// Error resulting from a prompt.
+pub enum PinPromptError {
+    /// PIN request was cancelled by the user.
+    Cancelled,
+
+    /// Any other error.
+    Other(Box<dyn std::error::Error + Send + Sync>),
+}
+
+#[allow(clippy::enum_variant_names)]
+enum GetPinUvAuthTokenOp {
+    GetPinUvAuthTokenUsingUvWithPermissions,
+    GetPinUvAuthTokenUsingPinWithPermissions,
+    GetPinToken,
+}
+
 /// A WebAuthn client backed by zero or more USB security keys serving as authenticators.
 pub struct LinuxClient<P, F>
 where
@@ -50,22 +83,45 @@ where
     devices: Vec<LinuxAuthenticator>,
     rp_id_verifier: RpIdVerifier<P, F>,
     uv_when_preferred: bool,
+    pin_prompt: Box<dyn PinPrompt>,
+    // TODO: support multiple pin protocols
+    pin_uv_auth_protocol_state: PinUvAuthProtocolOne,
 }
+
+#[derive(Clone)]
+struct TokenWithProtocol {
+    token: Bytes,
+    protocol: u8,
+}
+
+fn get_pin_auth_and_protocol(token_with_protocol: Option<TokenWithProtocol>, client_data_hash: &[u8]) -> (Option<Bytes>, Option<u8>) {
+        token_with_protocol
+            .map(|e| (
+                Some(Bytes::from(
+                    &hmac_sha256(e.token.as_slice(), client_data_hash)[0..16],
+                )),
+                Some(e.protocol)
+            ))
+            .unwrap_or((None, None))
+}
+
 
 impl LinuxClient<public_suffix::PublicSuffixList, ()> {
     /// Build a `LinuxClient` over the supplied authenticators using the default public-suffix list
     /// TLD provider.
-    pub fn new(authenticators: Vec<LinuxAuthenticator>) -> Self {
+    pub fn new(authenticators: Vec<LinuxAuthenticator>, pin_prompt: Box<dyn PinPrompt>) -> Self {
         Self {
             devices: authenticators,
             rp_id_verifier: RpIdVerifier::new(public_suffix::DEFAULT_PROVIDER, None),
             uv_when_preferred: true,
+            pin_prompt,
+            pin_uv_auth_protocol_state: PinUvAuthProtocolOne::new(),
         }
     }
 
     /// Enumerate every FIDO-capable USB HID device on the system and open each
     /// one. Devices that fail to open are skipped silently.
-    pub async fn open_all() -> Result<Self, OpenError> {
+    pub async fn open_all(pin_prompt: Box<dyn PinPrompt>) -> Result<Self, OpenError> {
         let infos = LinuxAuthenticator::list_devices()?;
         let mut authenticators = Vec::new();
         for info in infos {
@@ -73,7 +129,7 @@ impl LinuxClient<public_suffix::PublicSuffixList, ()> {
                 authenticators.push(auth);
             }
         }
-        Ok(Self::new(authenticators))
+        Ok(Self::new(authenticators, pin_prompt))
     }
 }
 
@@ -87,11 +143,14 @@ where
         authenticators: Vec<LinuxAuthenticator>,
         custom_provider: P,
         fetcher: Option<F>,
+        pin_prompt: Box<dyn PinPrompt>,
     ) -> Self {
         Self {
             devices: authenticators,
             rp_id_verifier: RpIdVerifier::new(custom_provider, fetcher),
             uv_when_preferred: true,
+            pin_prompt,
+            pin_uv_auth_protocol_state: PinUvAuthProtocolOne::new(),
         }
     }
 }
@@ -110,6 +169,151 @@ where
     /// How many authenticators this client will dispatch to.
     pub fn device_count(&self) -> usize {
         self.devices.len()
+    }
+
+    /// Return "valid" devices (devices that can be used for this combination of UV/PIN
+    /// configuration). Invalid devices are left in self.devices.
+    async fn get_valid_devices(
+        &mut self,
+        uv: bool,
+        rp_id: &str,
+    ) -> Result<Vec<(LinuxAuthenticator, Option<TokenWithProtocol>)>, WebauthnError> {
+        let mut devices = std::mem::take(&mut self.devices);
+
+        // Determine if any device has been configured to use built-in UV or a PIN.
+        let any_device_requires_uv = devices
+            .iter()
+            .any(|device| 
+                device.uv_configured() || device.pin_configured()
+            );
+
+        // We need to prompt the user to provide UV if the request requires user verification OR if
+        // any device requires UV. In order to do this, we first need them to provide UP to an authenticator
+        // to select it.
+        let selected_devices = if uv || any_device_requires_uv {
+            let mut selected_device = if devices.len() == 1 {
+                devices.pop().unwrap()
+            } else {
+                let candidates = devices.into_iter().map(|e| (e, ())).collect();
+                let RaceOutcome {
+                    winner,
+                    mut errors,
+                    losers,
+                } = race_request(candidates, |mut auth, _| async move {
+                    let result = auth.inner.authenticator_selection().await;
+                    (auth, result)
+                })
+                .await;
+
+                // Put losers back into the devices list
+                self.devices.extend(losers);
+                if let Some((_, winning_device)) = winner {
+                    winning_device
+                } else {
+                    return Err(WebauthnError::AuthenticatorError(errors.pop().unwrap_or(
+                        ctap2::StatusCode::Ctap2(
+                                ctap2::Ctap2Code::Known(ctap2::Ctap2Error::UserPresenceRequired)
+                        )
+                    ).into()));
+                }
+            };
+
+            let selected_operation = if selected_device.uv_configured() {
+                if selected_device.pin_uv_auth_token_supported() {
+                    // Use UV
+                    Some(GetPinUvAuthTokenOp::GetPinUvAuthTokenUsingUvWithPermissions)
+                } else {
+                    // Just set uv = true in request
+                    // TODO: retry with PIN if we get error code 0x36
+                    None
+                }
+            } else if selected_device.pin_configured() {
+                if selected_device.pin_uv_auth_token_supported() {
+                    // Use PIN
+                    Some(GetPinUvAuthTokenOp::GetPinUvAuthTokenUsingPinWithPermissions)
+                } else {
+                    Some(GetPinUvAuthTokenOp::GetPinToken)
+                }
+            } else {
+                // Dispatch request with no pinUvAuthToken to selected authenticator
+                None
+            };
+
+            let token_with_protocol = self.get_auth_token_for_device(&mut selected_device, selected_operation, rp_id).await?;
+
+            vec![(selected_device, token_with_protocol)]
+        } else {
+            // The request doesn't require UV, and no authenticator device requires UV.
+            // Therefore, do the regular authentication flow (race all authenticators).
+            devices.into_iter().map(|e| (e, None)).collect()
+        };
+        Ok(selected_devices)
+    }
+
+    // Take a device and an operation and obtain an auth token for that device using the method
+    // appropriate to the operation.
+    async fn get_auth_token_for_device(
+        &self,
+        selected_device: &mut LinuxAuthenticator,
+        selected_operation: Option<GetPinUvAuthTokenOp>,
+        rp_id: &str,
+    ) -> Result<Option<TokenWithProtocol>, WebauthnError> {
+        let token_and_protocol = match selected_operation {
+            None => None,
+            Some(op) => {
+                // Obtain platform key-agreement key and shared secret.
+                let pin_uv_auth_protocol = 1;
+                let public_key = selected_device.inner.get_public_key(pin_uv_auth_protocol).await?;
+                let (platform_key_agreement_key, shared_secret) = self.pin_uv_auth_protocol_state.encapsulate(&public_key).map_err(ctap2::StatusCode::from)?;
+                let permissions = ctap2::client_pin::Permissions::MC | ctap2::client_pin::Permissions::GA;
+                let encrypted_token = match op {
+                    GetPinUvAuthTokenOp::GetPinUvAuthTokenUsingPinWithPermissions => {
+                        let attempts_remaining = selected_device.inner.get_pin_retries(pin_uv_auth_protocol).await?;
+                        let pin = self.pin_prompt.request_pin(attempts_remaining).await.map_err(|_| WebauthnError::NotSupportedError)?;
+                        let encrypted_pin = aes_256_cbc(
+                            shared_secret,
+                            [0; 16],
+                            &sha256(pin.as_bytes())[0..16]
+                        ).into();
+                        selected_device.inner.get_pin_uv_auth_token_using_pin(
+                            pin_uv_auth_protocol,
+                            platform_key_agreement_key,
+                            encrypted_pin,
+                            permissions,
+                            Some(rp_id.to_owned()),
+                        ).await?
+                    }
+                    GetPinUvAuthTokenOp::GetPinUvAuthTokenUsingUvWithPermissions => {
+                        selected_device.inner.get_pin_uv_auth_token_using_uv(
+                            pin_uv_auth_protocol,
+                            platform_key_agreement_key,
+                            permissions,
+                            Some(rp_id.to_owned()),
+                        ).await?
+                    }
+                    GetPinUvAuthTokenOp::GetPinToken => {
+                        // TODO: use getUvRetries here
+                        let attempts_remaining = selected_device.inner.get_pin_retries(pin_uv_auth_protocol).await?;
+                        let pin = self.pin_prompt.request_pin(attempts_remaining).await.map_err(|_| WebauthnError::NotSupportedError)?;
+                        let encrypted_pin = aes_256_cbc(
+                            shared_secret,
+                            [0; 16],
+                            &sha256(pin.as_bytes())[0..16]
+                        ).into();
+                        selected_device.inner.get_pin_token(
+                            pin_uv_auth_protocol,
+                            platform_key_agreement_key,
+                            encrypted_pin,
+                        ).await?
+                    }
+                };
+
+                // Decrypt the token using the shared secret before returning it.
+                let pin_uv_auth_token = Bytes::from(PinUvAuthProtocolOne::decrypt(&shared_secret, encrypted_token.as_slice()));
+                Some((pin_uv_auth_token, pin_uv_auth_protocol))
+            }
+        };
+        Ok(token_and_protocol.map(|e| TokenWithProtocol { token: e.0, protocol: e.1 }))
     }
 
     /// Register a credential by racing every connected security key.
@@ -150,19 +354,19 @@ where
 
         // Per-device filter + tailored request build. Owned devices that don't
         // qualify are held aside so we can restore them after the race.
-        let devices = std::mem::take(&mut self.devices);
+        let selected_devices = self.get_valid_devices(uv, &rp_id).await?;
         let mut candidates: Vec<(LinuxAuthenticator, ctap2::make_credential::Request)> = Vec::new();
         let mut preserved: Vec<LinuxAuthenticator> = Vec::new();
-        for device in devices {
+        for (device, token_with_protocol) in selected_devices {
             let info = device.info();
 
             let rk = map_rk(opts.authenticator_selection.as_ref(), &info);
-            if rk && !info.options.as_ref().is_some_and(|o| o.rk) {
+            if rk && !device.rk_supported() {
                 // RP requires a resident key but this device can't store one.
                 preserved.push(device);
                 continue;
             }
-            if uv && !device_supports_uv(&info) {
+            if uv && !(device.uv_configured() || device.pin_configured()) {
                 // RP requires UV but this device has no built-in UV (and we don't implement
                 // clientPIN yet, so PIN-only devices can't satisfy `uv`).
                 preserved.push(device);
@@ -176,6 +380,8 @@ where
                 continue;
             }
 
+
+            let (pin_auth, pin_protocol) = get_pin_auth_and_protocol(token_with_protocol, &client_data_hash);
             let request = ctap2::make_credential::Request {
                 client_data_hash: client_data_hash.clone().into(),
                 rp: ctap2::make_credential::PublicKeyCredentialRpEntity {
@@ -187,14 +393,14 @@ where
                 exclude_list: opts.exclude_credentials.clone(),
                 extensions: None,
                 options: ctap2::make_credential::Options { rk, up: false, uv },
-                pin_auth: None,
-                pin_protocol: None,
+                pin_auth,
+                pin_protocol,
             };
             candidates.push((device, request));
         }
 
         if candidates.is_empty() {
-            self.devices = preserved;
+            self.devices.extend(preserved);
             return Err(WebauthnError::NotSupportedError);
         }
 
@@ -283,29 +489,29 @@ where
 
         let uv = ctap_uv_option(opts.user_verification, self.uv_when_preferred);
 
-        let devices = std::mem::take(&mut self.devices);
+        let selected_devices = self.get_valid_devices(uv, &rp_id).await?;
         let mut candidates: Vec<(LinuxAuthenticator, ctap2::get_assertion::Request)> = Vec::new();
         let mut preserved: Vec<LinuxAuthenticator> = Vec::new();
-        for device in devices {
-            let info = device.info();
-            if uv && !device_supports_uv(&info) {
+        for (device, token_with_protocol) in selected_devices {
+            if uv && !(device.uv_configured() || device.pin_configured()) {
                 preserved.push(device);
                 continue;
             }
+            let (pin_auth, pin_protocol) = get_pin_auth_and_protocol(token_with_protocol, &client_data_hash);
             let request = ctap2::get_assertion::Request {
                 rp_id: rp_id.clone(),
                 client_data_hash: client_data_hash.clone().into(),
                 allow_list: opts.allow_credentials.clone(),
                 extensions: None,
                 options: ctap2::get_assertion::Options { up: true, uv },
-                pin_auth: None,
-                pin_protocol: None,
+                pin_auth,
+                pin_protocol,
             };
             candidates.push((device, request));
         }
 
         if candidates.is_empty() {
-            self.devices = preserved;
+            self.devices.extend(preserved);
             return Err(WebauthnError::NotSupportedError);
         }
 
@@ -359,12 +565,6 @@ where
             client_extension_results: Default::default(),
         })
     }
-}
-
-/// Whether the given `get_info::Response` indicates that the device supports a user verification
-/// method that's already configured.
-fn device_supports_uv(info: &ctap2::get_info::Response) -> bool {
-    info.options.as_ref().and_then(|o| o.uv).unwrap_or(false)
 }
 
 /// Keep only the algorithms the device's `get_info` advertises (if it advertises any). The

--- a/passkey-types/Cargo.toml
+++ b/passkey-types/Cargo.toml
@@ -39,7 +39,6 @@ url = { version = "2", features = ["serde"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 # TODO: investigate rolling our own IANA listings and COSE keys
 coset = { workspace = true }
-# TODO: feature gate this for Linux
 p256 = { version = "0.13", features = ["arithmetic", "ecdh", "jwk", "pem"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/passkey-types/Cargo.toml
+++ b/passkey-types/Cargo.toml
@@ -18,11 +18,13 @@ workspace = true
 [features]
 default = []
 serialize_bytes_as_base64_string = []
-testable = ["dep:p256"]
+testable = []
 typeshare = ["dep:typeshare"]
 
 [dependencies]
-bitflags = "2"
+aes = "0.8"
+bitflags = { version = "2", features = ["serde"] }
+cbc = "0.1"
 ciborium = "0.2"
 data-encoding = "2"
 hmac = "0.12"
@@ -37,11 +39,8 @@ url = { version = "2", features = ["serde"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 # TODO: investigate rolling our own IANA listings and COSE keys
 coset = { workspace = true }
-p256 = { version = "0.13", features = [
-  "arithmetic",
-  "jwk",
-  "pem",
-], optional = true }
+# TODO: feature gate this for Linux
+p256 = { version = "0.13", features = ["arithmetic", "ecdh", "jwk", "pem"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/passkey-types/src/ctap2.rs
+++ b/passkey-types/src/ctap2.rs
@@ -10,9 +10,11 @@ mod commands;
 mod error;
 mod flags;
 
+pub mod client_pin;
 pub mod extensions;
 pub mod get_assertion;
 pub mod get_info;
 pub mod make_credential;
+pub mod pin_uv_auth_protocol;
 
 pub use self::{aaguid::*, attestation_fmt::*, commands::*, error::*, flags::*};

--- a/passkey-types/src/ctap2/client_pin.rs
+++ b/passkey-types/src/ctap2/client_pin.rs
@@ -1,0 +1,108 @@
+//! <https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorClientPIN>
+use bitflags::bitflags;
+use serde::{Deserialize, Serialize};
+
+use crate::Bytes;
+
+serde_workaround! {
+    /// Request type for the authenticatorClientPin command.
+    pub struct Request {
+        /// PIN/UV protocol chosen by the Client.
+        #[serde(rename = 0x01; default, skip_serializing_if = Option::is_none)]
+        pub pin_uv_auth_protocol: Option<u8>,
+
+        /// TODO: make this just use the subcommand enum
+        #[serde(rename = 0x02)]
+        pub sub_command: u8,
+
+        /// The platform key-agreement key.
+        #[serde(
+            rename = 0x03;
+            default,
+            skip_serializing_if = Option::is_none,
+            serialize_with = crate::utils::serde::cose_key::option::serialize,
+            deserialize_with = crate::utils::serde::cose_key::option::deserialize
+        )]
+        pub key_agreement: Option<coset::CoseKey>,
+
+        /// The output of calling authenticate on some context specific to the subcommand. 
+        #[serde(rename = 0x04; default, skip_serializing_if = Option::is_none)]
+        pub pin_uv_auth_param: Option<Bytes>,
+
+        /// An encrypted PIN. 
+        #[serde(rename = 0x05; default, skip_serializing_if = Option::is_none)]
+        pub new_pin_enc: Option<Bytes>,
+
+        /// An encrypted proof-of-knowledge of a PIN. 
+        #[serde(rename = 0x06; default, skip_serializing_if = Option::is_none)]
+        pub pin_hash_enc: Option<Bytes>,
+
+        /// Bitfield of permissions. If present, MUST NOT be 0.
+        #[serde(rename = 0x09; default, skip_serializing_if = Option::is_none)]
+        pub permissions: Option<Permissions>,
+
+        /// The RP ID to assign as the permissions RP ID. 
+        #[serde(rename = 0x0A; default, skip_serializing_if = Option::is_none)]
+        pub rp_id: Option<String>,
+    }
+}
+
+serde_workaround! {
+    /// authenticatorClientPin response.
+    #[derive(Default)]
+    pub struct Response {
+        /// Result of getPublicKey.
+        #[serde(
+            rename = 0x01;
+            default,
+            serialize_with = crate::utils::serde::cose_key::option::serialize,
+            deserialize_with = crate::utils::serde::cose_key::option::deserialize
+        )]
+        pub key_agreement: Option<coset::CoseKey>,
+
+        /// The pinUvAuthToken, encrypted by calling encrypt with the shared secret as the key.
+        #[serde(rename = 0x02; default, skip_serializing_if = Option::is_none)]
+        pub pin_uv_auth_token: Option<Bytes>,
+
+        /// Number of PIN attempts remaining before lockout.
+        #[serde(rename = 0x03; default, skip_serializing_if = Option::is_none)]
+        pub pin_retries: Option<u32>,
+
+        /// Present and true if the authenticator requires a power cycle before any future PIN
+        /// operation, false if no power cycle needed. If the field is omitted, no information is
+        /// given about whether a power cycle is needed or not. 
+        #[serde(rename = 0x04; default, skip_serializing_if = Option::is_none)]
+        pub power_cycle_state: Option<bool>,
+
+        /// Number of uv attempts remaining before lockout.
+        #[serde(rename = 0x05; default, skip_serializing_if = Option::is_none)]
+        pub uv_retries: Option<u32>,
+    }
+}
+
+bitflags! {
+    /// Permissions field of `authenticatorClientPin` request.
+    #[derive(Serialize, Deserialize)]
+    pub struct Permissions: u8 {
+        /// MakeCredential
+        const MC = 0x01;
+
+        /// GetAssertion
+        const GA = 0x02;
+
+        /// Credential Management
+        const CM = 0x04;
+
+        /// Bio Enrollment
+        const BE = 0x08;
+
+        /// Large Blob Write
+        const LBW = 0x10;
+
+        /// Authenticator Configuration
+        const ACFG = 0x20;
+
+        /// Persistent Credential Management Read Only
+        const PCMR = 0x40;
+    }
+}

--- a/passkey-types/src/ctap2/client_pin.rs
+++ b/passkey-types/src/ctap2/client_pin.rs
@@ -3,6 +3,7 @@ use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
 
 use crate::Bytes;
+use crate::ctap2::commands::Ctap2ClientPinSubcommand;
 
 serde_workaround! {
     /// Request type for the authenticatorClientPin command.
@@ -11,9 +12,9 @@ serde_workaround! {
         #[serde(rename = 0x01; default, skip_serializing_if = Option::is_none)]
         pub pin_uv_auth_protocol: Option<u8>,
 
-        /// TODO: make this just use the subcommand enum
+        /// The specific action being requested.
         #[serde(rename = 0x02)]
-        pub sub_command: u8,
+        pub sub_command: Ctap2ClientPinSubcommand,
 
         /// The platform key-agreement key.
         #[serde(

--- a/passkey-types/src/ctap2/client_pin.rs
+++ b/passkey-types/src/ctap2/client_pin.rs
@@ -25,15 +25,15 @@ serde_workaround! {
         )]
         pub key_agreement: Option<coset::CoseKey>,
 
-        /// The output of calling authenticate on some context specific to the subcommand. 
+        /// The output of calling authenticate on some context specific to the subcommand.
         #[serde(rename = 0x04; default, skip_serializing_if = Option::is_none)]
         pub pin_uv_auth_param: Option<Bytes>,
 
-        /// An encrypted PIN. 
+        /// An encrypted PIN.
         #[serde(rename = 0x05; default, skip_serializing_if = Option::is_none)]
         pub new_pin_enc: Option<Bytes>,
 
-        /// An encrypted proof-of-knowledge of a PIN. 
+        /// An encrypted proof-of-knowledge of a PIN.
         #[serde(rename = 0x06; default, skip_serializing_if = Option::is_none)]
         pub pin_hash_enc: Option<Bytes>,
 
@@ -41,7 +41,7 @@ serde_workaround! {
         #[serde(rename = 0x09; default, skip_serializing_if = Option::is_none)]
         pub permissions: Option<Permissions>,
 
-        /// The RP ID to assign as the permissions RP ID. 
+        /// The RP ID to assign as the permissions RP ID.
         #[serde(rename = 0x0A; default, skip_serializing_if = Option::is_none)]
         pub rp_id: Option<String>,
     }
@@ -70,7 +70,7 @@ serde_workaround! {
 
         /// Present and true if the authenticator requires a power cycle before any future PIN
         /// operation, false if no power cycle needed. If the field is omitted, no information is
-        /// given about whether a power cycle is needed or not. 
+        /// given about whether a power cycle is needed or not.
         #[serde(rename = 0x04; default, skip_serializing_if = Option::is_none)]
         pub power_cycle_state: Option<bool>,
 

--- a/passkey-types/src/ctap2/commands.rs
+++ b/passkey-types/src/ctap2/commands.rs
@@ -7,11 +7,37 @@ pub enum Ctap2Command {
     GetAssertion = 0x02,
     /// CTAP_CMD_GET_INFO
     GetInfo = 0x04,
+    /// CTAP_CMD_CLIENT_PIN
+    ClientPin = 0x06,
+    /// CTAP_CMD_AUTHENTICATOR_SELECTION
+    AuthenticatorSelection = 0x0B,
 }
 
 impl From<Ctap2Command> for u8 {
     #[expect(clippy::as_conversions)]
     fn from(value: Ctap2Command) -> Self {
+        value as u8
+    }
+}
+
+/// Possible values for `subCommand` field of `clientPin` request.
+#[repr(u8)]
+pub enum Ctap2ClientPinSubcommand {
+    /// getPinRetries
+    GetPinRetries = 0x01,
+    /// getKeyAgreement
+    GetKeyAgreement = 0x02,
+    /// getPinToken
+    GetPinToken = 0x05,
+    /// getPinUvAuthTokenUsingUvWithPermissions
+    GetPinUvAuthTokenUsingUvWithPermissions = 0x06,
+    /// getPinUvAuthTokenUsingPinWithPermissions
+    GetPinUvAuthTokenUsingPinWithPermissions = 0x09,
+}
+
+impl From<Ctap2ClientPinSubcommand> for u8 {
+    #[expect(clippy::as_conversions)]
+    fn from(value: Ctap2ClientPinSubcommand) -> Self {
         value as u8
     }
 }

--- a/passkey-types/src/ctap2/commands.rs
+++ b/passkey-types/src/ctap2/commands.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 /// Authenticator commands enumerated by the CTAP 2 specification.
 #[repr(u8)]
 pub enum Ctap2Command {
@@ -21,6 +23,8 @@ impl From<Ctap2Command> for u8 {
 }
 
 /// Possible values for `subCommand` field of `clientPin` request.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(into = "u8")]
 #[repr(u8)]
 pub enum Ctap2ClientPinSubcommand {
     /// getPinRetries
@@ -31,6 +35,8 @@ pub enum Ctap2ClientPinSubcommand {
     GetPinToken = 0x05,
     /// getPinUvAuthTokenUsingUvWithPermissions
     GetPinUvAuthTokenUsingUvWithPermissions = 0x06,
+    /// getUvRetires
+    GetUvRetries = 0x07,
     /// getPinUvAuthTokenUsingPinWithPermissions
     GetPinUvAuthTokenUsingPinWithPermissions = 0x09,
 }

--- a/passkey-types/src/ctap2/pin_uv_auth_protocol.rs
+++ b/passkey-types/src/ctap2/pin_uv_auth_protocol.rs
@@ -99,7 +99,9 @@ fn cose_to_p256_public(key: &CoseKey) -> Result<PublicKey, Ctap2Error> {
         let Label::Int(i) = label else { continue };
         match Ec2KeyParameter::from_i64(*i) {
             Some(Ec2KeyParameter::Crv) => {
-                crv = value.as_integer().and_then(|n| i128::from(n).try_into().ok());
+                crv = value
+                    .as_integer()
+                    .and_then(|n| i128::from(n).try_into().ok());
             }
             Some(Ec2KeyParameter::X) => x = value.as_bytes(),
             Some(Ec2KeyParameter::Y) => y = value.as_bytes(),

--- a/passkey-types/src/ctap2/pin_uv_auth_protocol.rs
+++ b/passkey-types/src/ctap2/pin_uv_auth_protocol.rs
@@ -1,0 +1,154 @@
+//! Client-side implementation of the PIN/UV Auth Protocols defined in CTAP2.
+//! Currently only implements Protocol One.
+
+use coset::{
+    CoseKey, CoseKeyBuilder, Label, RegisteredLabel,
+    iana::{Algorithm, Ec2KeyParameter, EllipticCurve, EnumI64, KeyType},
+};
+use p256::{
+    EncodedPoint, PublicKey, SecretKey,
+    ecdh::diffie_hellman,
+    elliptic_curve::{
+        generic_array::GenericArray,
+        sec1::{FromEncodedPoint, ToEncodedPoint},
+    },
+};
+use rand::rngs::OsRng;
+
+use crate::{
+    ctap2::Ctap2Error,
+    utils::crypto::{aes_256_cbc_decrypt, sha256},
+};
+
+/// Client-side state for PIN/UV Auth Protocol One. Holds the client's ephemeral P-256 key agreement
+/// key.
+pub struct PinUvAuthProtocolOne {
+    key_agreement: SecretKey,
+}
+
+impl PinUvAuthProtocolOne {
+    /// Create a new protocol instance with a freshly generated key agreement keypair.
+    pub fn new() -> Self {
+        Self {
+            key_agreement: SecretKey::random(&mut OsRng),
+        }
+    }
+
+    /// Replace the key agreement keypair with a fresh one.
+    pub fn regenerate(&mut self) {
+        self.key_agreement = SecretKey::random(&mut OsRng);
+    }
+
+    /// COSE_Key encoding of `xB`.
+    ///
+    /// Headers per spec: `kty=EC2(2)`, `alg=-25` ("not the algorithm actually used"),
+    /// `crv=P-256(1)`, `x` and `y` as 32-byte big-endian coordinates.
+    pub fn get_public_key(&self) -> CoseKey {
+        let point = self.key_agreement.public_key().to_encoded_point(false);
+        // SAFETY: an uncompressed P-256 point always carries both coordinates.
+        let x = point.x().unwrap().as_slice().to_vec();
+        let y = point.y().unwrap().as_slice().to_vec();
+        CoseKeyBuilder::new_ec2_pub_key(EllipticCurve::P_256, x, y)
+            .algorithm(Algorithm::ECDH_ES_HKDF_256)
+            .build()
+    }
+
+    /// Returns the client's own public key plus the derived shared secret to
+    /// send to/use with the authenticator whose public key is `peer`.
+    pub fn encapsulate(&self, peer: &CoseKey) -> Result<(CoseKey, [u8; 32]), Ctap2Error> {
+        let shared_secret = self.ecdh(peer)?;
+        Ok((self.get_public_key(), shared_secret))
+    }
+
+    /// AES-256-CBC-Decrypt with a zero IV and no padding.
+    pub fn decrypt(key: &[u8; 32], ciphertext: &[u8]) -> Vec<u8> {
+        aes_256_cbc_decrypt(*key, [0; 16], ciphertext)
+    }
+
+    /// 1. Parse `peer` as a P-256 point `Y`; reject if not on the curve.
+    /// 2. Compute `xY` with the local private key.
+    /// 3. `Z` = 32-byte big-endian encoding of the x-coordinate of `xY`.
+    /// 4. Return `kdf(Z) = SHA-256(Z)`.
+    fn ecdh(&self, peer: &CoseKey) -> Result<[u8; 32], Ctap2Error> {
+        let peer_public = cose_to_p256_public(peer)?;
+        // `SharedSecret::raw_secret_bytes()` is exactly Z - the BE x-coord of xY.
+        let shared = diffie_hellman(
+            self.key_agreement.to_nonzero_scalar(),
+            peer_public.as_affine(),
+        );
+        Ok(sha256(shared.raw_secret_bytes().as_slice()))
+    }
+}
+
+impl Default for PinUvAuthProtocolOne {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Parse the COSE_Key shape required by get_public_key into a `p256::PublicKey`. The `alg` header
+/// is intentionally ignored: the spec mandates writing `-25` there but explicitly notes it is not
+/// the algorithm actually in use.
+fn cose_to_p256_public(key: &CoseKey) -> Result<PublicKey, Ctap2Error> {
+    if !matches!(key.kty, RegisteredLabel::Assigned(KeyType::EC2)) {
+        return Err(Ctap2Error::InvalidCredential);
+    }
+
+    let (mut crv, mut x, mut y) = (None, None, None);
+    for (label, value) in &key.params {
+        let Label::Int(i) = label else { continue };
+        match Ec2KeyParameter::from_i64(*i) {
+            Some(Ec2KeyParameter::Crv) => {
+                crv = value.as_integer().and_then(|n| i128::from(n).try_into().ok());
+            }
+            Some(Ec2KeyParameter::X) => x = value.as_bytes(),
+            Some(Ec2KeyParameter::Y) => y = value.as_bytes(),
+            _ => {}
+        }
+    }
+
+    if crv != Some(EllipticCurve::P_256.to_i64()) {
+        return Err(Ctap2Error::InvalidCredential);
+    }
+    let (Some(x), Some(y)) = (x, y) else {
+        return Err(Ctap2Error::CborUnexpectedType);
+    };
+
+    let point = EncodedPoint::from_affine_coordinates(
+        GenericArray::from_slice(x),
+        GenericArray::from_slice(y),
+        false,
+    );
+    Option::<PublicKey>::from(PublicKey::from_encoded_point(&point))
+        .ok_or(Ctap2Error::InvalidCredential)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encapsulate_and_decapsulate_agree() {
+        // Two independent instances stand in for client and authenticator.
+        let client = PinUvAuthProtocolOne::new();
+        let authenticator = PinUvAuthProtocolOne::new();
+
+        let (client_public, client_shared) = client
+            .encapsulate(&authenticator.get_public_key())
+            .expect("encapsulate succeeds for a valid peer");
+
+        // Authenticator-side derivation of the same secret via ecdh(clientPublic).
+        let auth_shared = authenticator
+            .ecdh(&client_public)
+            .expect("ecdh succeeds for a valid peer");
+
+        assert_eq!(client_shared, auth_shared);
+    }
+
+    #[test]
+    fn rejects_non_ec2_key() {
+        let proto = PinUvAuthProtocolOne::new();
+        let bogus = CoseKeyBuilder::new_symmetric_key(vec![0; 32]).build();
+        assert!(proto.encapsulate(&bogus).is_err());
+    }
+}

--- a/passkey-types/src/utils/crypto.rs
+++ b/passkey-types/src/utils/crypto.rs
@@ -1,5 +1,7 @@
 //! Collection of common cryptography primitives used in serialization of types.
 
+use aes::Aes256;
+use aes::cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit, generic_array::GenericArray};
 use hmac::{Hmac, Mac};
 use sha2::{Digest, Sha256};
 
@@ -15,4 +17,98 @@ pub fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
     mac.update(data);
 
     mac.finalize().into_bytes().into()
+}
+
+const AES_BLOCK_SIZE: usize = 16;
+
+/// AES-256-CBC encryption of `data` under `key` with the given `iv`, with no padding.
+pub fn aes_256_cbc(key: [u8; 32], iv: [u8; 16], data: &[u8]) -> Vec<u8> {
+    assert!(
+        data.len() % AES_BLOCK_SIZE == 0,
+        "plaintext length must be a multiple of the AES block size",
+    );
+    let mut cipher = cbc::Encryptor::<Aes256>::new(
+        GenericArray::from_slice(&key),
+        GenericArray::from_slice(&iv),
+    );
+    let mut out = vec![0u8; data.len()];
+    for (in_chunk, out_chunk) in data
+        .chunks_exact(AES_BLOCK_SIZE)
+        .zip(out.chunks_exact_mut(AES_BLOCK_SIZE))
+    {
+        cipher.encrypt_block_b2b_mut(
+            GenericArray::from_slice(in_chunk),
+            GenericArray::from_mut_slice(out_chunk),
+        );
+    }
+    out
+}
+
+/// AES-256-CBC decryption of `data` under `key` with the given `iv`, with no padding.
+/// Mirror of [`aes_256_cbc`].
+pub fn aes_256_cbc_decrypt(key: [u8; 32], iv: [u8; 16], data: &[u8]) -> Vec<u8> {
+    assert!(
+        data.len() % AES_BLOCK_SIZE == 0,
+        "ciphertext length must be a multiple of the AES block size",
+    );
+    let mut cipher = cbc::Decryptor::<Aes256>::new(
+        GenericArray::from_slice(&key),
+        GenericArray::from_slice(&iv),
+    );
+    let mut out = vec![0u8; data.len()];
+    for (in_chunk, out_chunk) in data
+        .chunks_exact(AES_BLOCK_SIZE)
+        .zip(out.chunks_exact_mut(AES_BLOCK_SIZE))
+    {
+        cipher.decrypt_block_b2b_mut(
+            GenericArray::from_slice(in_chunk),
+            GenericArray::from_mut_slice(out_chunk),
+        );
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aes_256_cbc_zero_iv_roundtrip_via_decrypt() {
+        use aes::cipher::BlockDecryptMut;
+
+        let key = [0x42u8; 32];
+        let iv = [0u8; AES_BLOCK_SIZE];
+        let plaintext = b"plaintext_b1_!!!plaintext_b2_!!!"; // 32 bytes, two blocks
+        assert_eq!(plaintext.len(), 32);
+
+        let ct = aes_256_cbc(key, iv, plaintext);
+        assert_eq!(ct.len(), plaintext.len());
+        assert_ne!(ct.as_slice(), plaintext.as_slice());
+        // CBC chains — identical plaintext blocks must NOT yield identical
+        // ciphertext blocks under a non-zero IV-chained encryption.
+        assert_ne!(&ct[..AES_BLOCK_SIZE], &ct[AES_BLOCK_SIZE..]);
+
+        // Decrypt with the symmetric primitive to confirm correctness.
+        let mut cipher = cbc::Decryptor::<Aes256>::new(
+            GenericArray::from_slice(&key),
+            GenericArray::from_slice(&iv),
+        );
+        let mut pt = vec![0u8; ct.len()];
+        for (i, o) in ct
+            .chunks_exact(AES_BLOCK_SIZE)
+            .zip(pt.chunks_exact_mut(AES_BLOCK_SIZE))
+        {
+            cipher.decrypt_block_b2b_mut(
+                GenericArray::from_slice(i),
+                GenericArray::from_mut_slice(o),
+            );
+        }
+        assert_eq!(pt.as_slice(), plaintext.as_slice());
+    }
+
+    #[test]
+    fn aes_256_cbc_empty_input() {
+        let ct = aes_256_cbc([0u8; 32], [0u8; AES_BLOCK_SIZE], &[]);
+        assert!(ct.is_empty());
+    }
 }

--- a/passkey-types/src/utils/serde.rs
+++ b/passkey-types/src/utils/serde.rs
@@ -106,6 +106,62 @@ pub mod i64_to_iana {
     }
 }
 
+/// Adapters for `serde_workaround` to (de)serialize a `coset::CoseKey` as an inline CBOR map,
+/// the wire form used by CTAP2 (e.g. authenticatorClientPIN `keyAgreement`).
+pub mod cose_key {
+    use ciborium::value::Value;
+    use coset::AsCborValue;
+
+    pub fn serialize<S>(value: &coset::CoseKey, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let cbor = value
+            .clone()
+            .to_cbor_value()
+            .map_err(serde::ser::Error::custom)?;
+        serde::Serialize::serialize(&cbor, ser)
+    }
+
+    #[allow(dead_code)]
+    pub fn deserialize<'de, D>(de: D) -> Result<coset::CoseKey, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = <Value as serde::Deserialize>::deserialize(de)?;
+        coset::CoseKey::from_cbor_value(value).map_err(serde::de::Error::custom)
+    }
+
+    pub mod option {
+        use ciborium::value::Value;
+        use coset::AsCborValue;
+
+        pub fn serialize<S>(value: &Option<coset::CoseKey>, ser: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            match value {
+                Some(v) => super::serialize(v, ser),
+                None => ser.serialize_none(),
+            }
+        }
+
+        pub fn deserialize<'de, D>(de: D) -> Result<Option<coset::CoseKey>, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            let value = <Value as serde::Deserialize>::deserialize(de)?;
+            if matches!(value, Value::Null) {
+                Ok(None)
+            } else {
+                coset::CoseKey::from_cbor_value(value)
+                    .map(Some)
+                    .map_err(serde::de::Error::custom)
+            }
+        }
+    }
+}
+
 struct StringOrNum<T>(pub std::marker::PhantomData<T>);
 
 impl<T> Visitor<'_> for StringOrNum<T>

--- a/passkey-types/src/utils/serde_workaround.rs
+++ b/passkey-types/src/utils/serde_workaround.rs
@@ -11,7 +11,7 @@ macro_rules! serde_workaround {
         $(#[$attr:meta])*
         pub struct $name:ident {$(
             $(#[doc=$doc:literal])*
-            #[serde(rename = $discriminant:literal$(;$default:ident)?$(,skip_serializing_if = $method:path)?$(,deserialize_with = $de:path)?)]
+            #[serde(rename = $discriminant:literal$(;$default:ident)?$(,skip_serializing_if = $method:path)?$(,serialize_with = $ser:path)?$(,deserialize_with = $de:path)?)]
             $vis:vis $field:ident: $ty:ty,
         )*}
     ) => {
@@ -59,7 +59,7 @@ macro_rules! serde_workaround {
                 {
                     let mut serde_state = serde::Serializer::serialize_map(serializer, Some(struct_len(&self)))?;
                     $(
-                        serde_serialize_entry!{serde_state; self.$field $(;$method)?}
+                        serde_serialize_entry!{serde_state; self.$field $(;skip = $method)? $(;ser = $ser, $ty)?}
                     )*
                     serde_state.end()
                 }
@@ -180,11 +180,30 @@ macro_rules! serde_workaround_struct_len {
 }
 
 macro_rules! serde_serialize_entry {
-    ($state:ident; $self:ident.$field:ident; $skip_if:path) => {
+    ($state:ident; $self:ident.$field:ident; skip = $skip_if:path; ser = $ser_with:path, $ty:ty) => {
+        if !$skip_if(&$self.$field) {
+            serde_serialize_entry!($state; $self.$field; ser = $ser_with, $ty)
+        }
+    };
+    ($state:ident; $self:ident.$field:ident; skip = $skip_if:path) => {
         if !$skip_if(&$self.$field) {
             serde_serialize_entry!($state; $self.$field)
         }
     };
+    ($state:ident; $self:ident.$field:ident; ser = $ser_with:path, $ty:ty) => {{
+        struct __SerializeWith<'__a> {
+            value: &'__a $ty,
+        }
+        impl<'__a> ::serde::Serialize for __SerializeWith<'__a> {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: ::serde::Serializer,
+            {
+                $ser_with(self.value, serializer)
+            }
+        }
+        $state.serialize_entry(&Ident::$field, &__SerializeWith { value: &$self.$field })?
+    }};
     ($state:ident; $self:ident.$field:ident) => {
         $state.serialize_entry(&Ident::$field, &$self.$field)?
     };

--- a/passkey/Cargo.toml
+++ b/passkey/Cargo.toml
@@ -42,3 +42,4 @@ passkey-client = { path = "../passkey-client", version = "0.6", features = [
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 tokio-test = "0.4"
 url = "2"
+zeroize = "1.9"

--- a/passkey/examples/linux.rs
+++ b/passkey/examples/linux.rs
@@ -1,12 +1,31 @@
 //! Sample App for Linux Client
+use std::io::{stdin, stdout, Write};
 use passkey::{
-    client::{WebauthnError, linux::LinuxClient},
+    client::{WebauthnError, linux::{LinuxClient, PinPrompt, PinPromptError}},
     types::{Bytes, rand::random_vec, webauthn::*},
 };
 
 use coset::iana;
 use passkey_client::DefaultClientData;
 use url::Url;
+use zeroize::Zeroizing;
+
+struct MyPinPrompt;
+
+#[async_trait::async_trait]
+impl PinPrompt for MyPinPrompt {
+     async fn prompt_authenticator_selection(&self, num_authenticators: usize) -> Result<(), PinPromptError> {
+        println!("Touch one of the {} attached authenticator devices to select it.", num_authenticators);
+        Ok(())
+    }
+     async fn request_pin(&self, attempts_remaining: u32) -> Result<Zeroizing<String>, PinPromptError> {
+         print!("Enter PIN ({} attempts remaining): ", attempts_remaining);
+         stdout().flush().map_err(|e| PinPromptError::Other(Box::new(e)))?;
+         let mut buf = String::new();
+         stdin().read_line(&mut buf).map_err(|e| PinPromptError::Other(Box::new(e)))?;
+         Ok(Zeroizing::new(buf.trim_ascii().into()))
+    }
+}
 
 // Example of how to set up, register and authenticate with a `Client`.
 async fn client_setup(
@@ -16,7 +35,7 @@ async fn client_setup(
     user_entity: PublicKeyCredentialUserEntity,
 ) -> Result<(CreatedPublicKeyCredential, AuthenticatedPublicKeyCredential), WebauthnError> {
     // Create the Client
-    let mut my_client = LinuxClient::open_all()
+    let mut my_client = LinuxClient::open_all(Box::new(MyPinPrompt))
         .await
         .unwrap()
         .user_verification_when_preferred(false);

--- a/passkey/examples/linux.rs
+++ b/passkey/examples/linux.rs
@@ -17,16 +17,6 @@ struct MyPinPrompt;
 
 #[async_trait::async_trait]
 impl PinPrompt for MyPinPrompt {
-    async fn prompt_authenticator_selection(
-        &self,
-        num_authenticators: usize,
-    ) -> Result<(), PinPromptError> {
-        println!(
-            "Touch one of the {} attached authenticator devices to select it.",
-            num_authenticators
-        );
-        Ok(())
-    }
     async fn request_pin(
         &self,
         attempts_remaining: u32,

--- a/passkey/examples/linux.rs
+++ b/passkey/examples/linux.rs
@@ -1,9 +1,12 @@
 //! Sample App for Linux Client
-use std::io::{stdin, stdout, Write};
 use passkey::{
-    client::{WebauthnError, linux::{LinuxClient, PinPrompt, PinPromptError}},
+    client::{
+        WebauthnError,
+        linux::{LinuxClient, PinPrompt, PinPromptError},
+    },
     types::{Bytes, rand::random_vec, webauthn::*},
 };
+use std::io::{Write, stdin, stdout};
 
 use coset::iana;
 use passkey_client::DefaultClientData;
@@ -14,16 +17,29 @@ struct MyPinPrompt;
 
 #[async_trait::async_trait]
 impl PinPrompt for MyPinPrompt {
-     async fn prompt_authenticator_selection(&self, num_authenticators: usize) -> Result<(), PinPromptError> {
-        println!("Touch one of the {} attached authenticator devices to select it.", num_authenticators);
+    async fn prompt_authenticator_selection(
+        &self,
+        num_authenticators: usize,
+    ) -> Result<(), PinPromptError> {
+        println!(
+            "Touch one of the {} attached authenticator devices to select it.",
+            num_authenticators
+        );
         Ok(())
     }
-     async fn request_pin(&self, attempts_remaining: u32) -> Result<Zeroizing<String>, PinPromptError> {
-         print!("Enter PIN ({} attempts remaining): ", attempts_remaining);
-         stdout().flush().map_err(|e| PinPromptError::Other(Box::new(e)))?;
-         let mut buf = String::new();
-         stdin().read_line(&mut buf).map_err(|e| PinPromptError::Other(Box::new(e)))?;
-         Ok(Zeroizing::new(buf.trim_ascii().into()))
+    async fn request_pin(
+        &self,
+        attempts_remaining: u32,
+    ) -> Result<Zeroizing<String>, PinPromptError> {
+        print!("Enter PIN ({} attempts remaining): ", attempts_remaining);
+        stdout()
+            .flush()
+            .map_err(|e| PinPromptError::Other(Box::new(e)))?;
+        let mut buf = String::new();
+        stdin()
+            .read_line(&mut buf)
+            .map_err(|e| PinPromptError::Other(Box::new(e)))?;
+        Ok(Zeroizing::new(buf.trim_ascii().into()))
     }
 }
 


### PR DESCRIPTION
Builds upon #99. Enables this library to be used with authenticators that are secured by a PIN or other UV method (such as biometrics). 