### PR TITLE
override supported algorithms

### DIFF
--- a/passkey-authenticator/src/authenticator.rs
+++ b/passkey-authenticator/src/authenticator.rs
@@ -171,6 +171,25 @@ where
         self.credential_id_length
     }
 
+    /// Override the crypto backend's algorithm enumeration into a subset of what it supports.
+    ///
+    /// If the provided list does not intersect with the crypto backend's supported algorithms,
+    /// this method will return an error.
+    pub fn set_algorithms(&mut self, algs: &[iana::Algorithm]) -> Result<(), Ctap2Error> {
+        // iana::Algorithm doesn't implement hash, so we gotta loop
+        let backend_supported = self.crypto.enumerate_algorithms();
+        let retained: Vec<_> = algs
+            .iter()
+            .filter(|alg| backend_supported.contains(*alg))
+            .cloned()
+            .collect();
+        if retained.is_empty() {
+            return Err(Ctap2Error::UnsupportedAlgorithm);
+        }
+        self.algs = retained;
+        Ok(())
+    }
+
     /// Access the [`CredentialStore`] to look into what is stored.
     pub fn store(&self) -> &S {
         &self.store


### PR DESCRIPTION
With the new backend, not all consuming applications may support storing all algorithms at the time of updating this dependency. This gives consumers the capability of overriding the list of supported algorithms by the authenticator. This list must be a subset of the list supported by the backend. If none are provided, the setter will error out.